### PR TITLE
Mention pixi-browse version in help screen

### DIFF
--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -19,6 +19,7 @@ from textual.containers import Horizontal, Vertical
 from textual.events import Key, Paste, Resize
 from textual.widgets import OptionList, Static
 
+from pixi_browse import __version__
 from pixi_browse.models import (
     DependencyTab,
     VersionDetailsData,
@@ -1239,7 +1240,7 @@ class CondaMetadataTui(App[None]):
         self._update_filter_indicator()
 
     def action_show_help(self) -> None:
-        self.push_screen(HelpScreen(self._help_text()))
+        self.push_screen(HelpScreen(self._help_text(), version=__version__))
 
     def action_open_external_url(self, url: str) -> None:
         webbrowser.open(url)

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -493,13 +493,17 @@ class HelpScreen(ModalScreen[None]):
         Binding("question_mark", "dismiss", show=False),
     ]
 
-    def __init__(self, help_text: str) -> None:
+    def __init__(self, help_text: str, *, version: str) -> None:
         super().__init__()
         self._help_text = help_text
+        self._version = version
+
+    def _title_text(self) -> str:
+        return f"pixi-browse v{self._version}"
 
     def compose(self) -> ComposeResult:
         with Vertical(id="help-dialog"):
-            yield Static("Keybinds", id="help-title")
+            yield Static(self._title_text(), id="help-title")
             yield Static(self._help_text, id="help-body")
 
     async def action_dismiss(self, result: None = None) -> None:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -12,6 +12,7 @@ from rich.style import Style
 from rich.text import Text
 from textual.events import Paste
 
+from pixi_browse import __version__
 from pixi_browse.__main__ import CondaMetadataTui, VersionEntry, VersionRow
 from pixi_browse.models import VersionDetailsData
 from pixi_browse.rendering import (
@@ -864,6 +865,7 @@ def test_action_show_help_pushes_help_screen(monkeypatch) -> None:
 
     assert len(pushed) == 1
     assert isinstance(pushed[0], HelpScreen)
+    assert pushed[0]._title_text() == f"pixi-browse v{__version__}"
 
 
 def test_action_open_external_url_uses_webbrowser(monkeypatch) -> None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Help dialog now displays the application version in its title, making it easier to identify which version of the application is running.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->