### PR TITLE
Display package symlinks

### DIFF
--- a/pixi_browse/models.py
+++ b/pixi_browse/models.py
@@ -38,6 +38,11 @@ class PackageFile:
     sha256: bytes | None = None
     no_link: bool | None = None
     path_type: PackageFilePathType | None = None
+    link_target: str | None = None
+
+    @property
+    def is_symlink(self) -> bool:
+        return self.path_type == "softlink"
 
 
 @dataclass(frozen=True)

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -466,6 +466,8 @@ def _package_file_summary(package_file: PackageFile) -> str:
         details.append(format_human_byte_size(package_file.size_in_bytes))
     if package_file.path_type is not None:
         details.append(package_file.path_type)
+    if package_file.link_target is not None:
+        details.append(f"target={package_file.link_target}")
     if package_file.no_link is not None:
         details.append(f"no_link={package_file.no_link}")
     if package_file.sha256 is not None:
@@ -480,6 +482,16 @@ def _files_differ(left: PackageFile, right: PackageFile) -> bool:
         left.sha256 is not None
         and right.sha256 is not None
         and left.sha256 != right.sha256
+    ):
+        return True
+    if left.is_symlink != right.is_symlink:
+        return True
+    if (
+        left.is_symlink
+        and right.is_symlink
+        and left.link_target is not None
+        and right.link_target is not None
+        and left.link_target != right.link_target
     ):
         return True
     return (
@@ -567,7 +579,16 @@ def _display_info_compare_rows(
             left_file=row.left_file,
             right_file=row.right_file,
             comparison_known=(
-                common_comparison_known or row.changed
+                common_comparison_known
+                or row.changed
+                or (
+                    row.left_file is not None
+                    and row.right_file is not None
+                    and row.left_file.is_symlink
+                    and row.right_file.is_symlink
+                    and row.left_file.link_target is not None
+                    and row.right_file.link_target is not None
+                )
                 if row.left_file is not None and row.right_file is not None
                 else True
             ),
@@ -596,6 +617,7 @@ def resolve_info_file_compare_rows(
             sha256=left_sha256.get(row.left_file.path),
             no_link=row.left_file.no_link,
             path_type=row.left_file.path_type,
+            link_target=row.left_file.link_target,
         )
         for row in rows
         if row.left_file is not None
@@ -607,6 +629,7 @@ def resolve_info_file_compare_rows(
             sha256=right_sha256.get(row.right_file.path),
             no_link=row.right_file.no_link,
             path_type=row.right_file.path_type,
+            link_target=row.right_file.link_target,
         )
         for row in rows
         if row.right_file is not None

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -1306,8 +1306,38 @@ class CondaMetadataTui(App[None]):
         return cast(CompareScreen, self.screen).selected_file_row()
 
     def _open_compare_file_action_screen(self, row: CompareFileRow) -> None:
+        actions = self._compare_file_action_options(row)
+        if not actions:
+            has_symlink = any(
+                package_file is not None and package_file.is_symlink
+                for package_file in (row.left_file, row.right_file)
+            )
+            self.notify(
+                (
+                    "Symlinks cannot be previewed or downloaded."
+                    if has_symlink
+                    else "This compare row does not map to a downloadable file."
+                ),
+                title="Files",
+                severity="warning",
+            )
+            return
+
+        self.push_screen(
+            FileActionScreen(
+                row.label,
+                actions=actions,
+                metadata_lines=self._compare_file_action_metadata_lines(row),
+            ),
+            lambda result: self._handle_compare_file_action_result(row, result),
+        )
+
+    @staticmethod
+    def _compare_file_action_options(
+        row: CompareFileRow,
+    ) -> tuple[FileActionOption, ...]:
         actions: list[FileActionOption] = []
-        if row.left_file is not None:
+        if row.left_file is not None and not row.left_file.is_symlink:
             actions.extend(
                 (
                     FileActionOption(
@@ -1318,7 +1348,7 @@ class CondaMetadataTui(App[None]):
                     ),
                 )
             )
-        if row.right_file is not None:
+        if row.right_file is not None and not row.right_file.is_symlink:
             actions.extend(
                 (
                     FileActionOption(
@@ -1329,22 +1359,7 @@ class CondaMetadataTui(App[None]):
                     ),
                 )
             )
-        if not actions:
-            self.notify(
-                "This compare row does not map to a downloadable file.",
-                title="Files",
-                severity="warning",
-            )
-            return
-
-        self.push_screen(
-            FileActionScreen(
-                row.label,
-                actions=tuple(actions),
-                metadata_lines=self._compare_file_action_metadata_lines(row),
-            ),
-            lambda result: self._handle_compare_file_action_result(row, result),
-        )
+        return tuple(actions)
 
     def _request_file_action_for_selected_compare_file(self) -> None:
         if self._file_action_in_progress:
@@ -1357,6 +1372,8 @@ class CondaMetadataTui(App[None]):
             compare_screen.active_file_tab() == "info"
             and row.left_file is not None
             and row.right_file is not None
+            and not row.left_file.is_symlink
+            and not row.right_file.is_symlink
             and (row.left_file.sha256 is None or row.right_file.sha256 is None)
         ):
             self._file_action_in_progress = True

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -974,6 +974,7 @@ class CondaMetadataTui(App[None]):
 
     @staticmethod
     async def _info_file_sha256(archive: PackageArchive, path: str) -> bytes:
+        # TODO: don't read in all bytes into memory but stream
         contents = await archive.read_file(path)
         assert contents is not None
         return sha256(contents).digest()

--- a/pixi_browse/tui/version_loader.py
+++ b/pixi_browse/tui/version_loader.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import yaml
 from rattler.networking import Client
 from rattler.package import PathType, RunExportsJson
@@ -92,6 +94,20 @@ class VersionDataLoader:
             )
             for path in paths_json.paths
         ]
+        symlink_paths = {path.path for path in paths if path.is_symlink}
+        if symlink_paths:
+            link_targets: dict[str, str | None] = {}
+            async for entry in archive.stream("pkg"):
+                if entry.is_symlink and entry.name in symlink_paths:
+                    link_targets[entry.name] = entry.link_target
+                    if len(link_targets) == len(symlink_paths):
+                        break
+            paths = [
+                replace(path, link_target=link_targets.get(path.path))
+                if path.is_symlink
+                else path
+                for path in paths
+            ]
         self.paths_cache[preview_key] = paths
         return paths
 

--- a/pixi_browse/tui/version_loader.py
+++ b/pixi_browse/tui/version_loader.py
@@ -170,6 +170,15 @@ class VersionDataLoader:
         async for entry in archive.stream("info"):
             if entry.is_file:
                 files.append(PackageFile(path=entry.name, size_in_bytes=entry.size))
+            elif entry.is_symlink:
+                files.append(
+                    PackageFile(
+                        path=entry.name,
+                        size_in_bytes=entry.size,
+                        path_type="softlink",
+                        link_target=entry.link_target,
+                    )
+                )
         return files
 
     async def get_run_exports(self, archive: PackageArchive) -> RunExportsJson | None:

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -548,12 +548,7 @@ class VersionDetailsView(Vertical):
     def _file_label(cls, package_file: PackageFile, tab: FileTab) -> str:
         path = cls._displayed_file_path(package_file.path, tab)
         if package_file.is_symlink:
-            target = (
-                f" -> {package_file.link_target}"
-                if package_file.link_target is not None
-                else ""
-            )
-            return f"{path}{target} (symlink)"
+            return f"{path} (symlink)"
         if package_file.size_in_bytes is not None:
             return f"{path} ({format_human_byte_size(package_file.size_in_bytes)})"
         return path
@@ -1366,12 +1361,7 @@ class CompareDetailsView(Vertical):
                 and row.left_file.is_symlink
                 and row.right_file.is_symlink
             ):
-                target = (
-                    f" -> {row.left_file.link_target}"
-                    if row.left_file.link_target is not None
-                    else ""
-                )
-                return f" (symlink{target})"
+                return " (symlink)"
             if not row.changed and left_size == right_size:
                 return (
                     f" ({format_human_byte_size(left_size)})"
@@ -1408,12 +1398,7 @@ class CompareDetailsView(Vertical):
     @staticmethod
     def _compare_file_side_label(package_file: PackageFile) -> str:
         if package_file.is_symlink:
-            target = (
-                f" -> {package_file.link_target}"
-                if package_file.link_target is not None
-                else ""
-            )
-            return f"symlink{target}"
+            return "symlink"
         if package_file.size_in_bytes is not None:
             return format_human_byte_size(package_file.size_in_bytes)
         return "unknown"

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -548,7 +548,12 @@ class VersionDetailsView(Vertical):
     def _file_label(cls, package_file: PackageFile, tab: FileTab) -> str:
         path = cls._displayed_file_path(package_file.path, tab)
         if package_file.is_symlink:
-            return f"{path} (symlink)"
+            target = (
+                f" -> {package_file.link_target}"
+                if package_file.link_target is not None
+                else ""
+            )
+            return f"{path}{target} (symlink)"
         if package_file.size_in_bytes is not None:
             return f"{path} ({format_human_byte_size(package_file.size_in_bytes)})"
         return path
@@ -1361,7 +1366,12 @@ class CompareDetailsView(Vertical):
                 and row.left_file.is_symlink
                 and row.right_file.is_symlink
             ):
-                return " (symlink)"
+                target = (
+                    f" -> {row.left_file.link_target}"
+                    if row.left_file.link_target is not None
+                    else ""
+                )
+                return f" (symlink{target})"
             if not row.changed and left_size == right_size:
                 return (
                     f" ({format_human_byte_size(left_size)})"
@@ -1398,7 +1408,12 @@ class CompareDetailsView(Vertical):
     @staticmethod
     def _compare_file_side_label(package_file: PackageFile) -> str:
         if package_file.is_symlink:
-            return "symlink"
+            target = (
+                f" -> {package_file.link_target}"
+                if package_file.link_target is not None
+                else ""
+            )
+            return f"symlink{target}"
         if package_file.size_in_bytes is not None:
             return format_human_byte_size(package_file.size_in_bytes)
         return "unknown"

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -548,12 +548,11 @@ class VersionDetailsView(Vertical):
     def _file_label(cls, package_file: PackageFile, tab: FileTab) -> str:
         path = cls._displayed_file_path(package_file.path, tab)
         if package_file.is_symlink:
-            target = (
-                f" -> {package_file.link_target}"
+            return (
+                f"{path} -> {package_file.link_target}"
                 if package_file.link_target is not None
-                else ""
+                else path
             )
-            return f"{path}{target} (symlink)"
         if package_file.size_in_bytes is not None:
             return f"{path} ({format_human_byte_size(package_file.size_in_bytes)})"
         return path
@@ -1366,12 +1365,11 @@ class CompareDetailsView(Vertical):
                 and row.left_file.is_symlink
                 and row.right_file.is_symlink
             ):
-                target = (
+                return (
                     f" -> {row.left_file.link_target}"
                     if row.left_file.link_target is not None
                     else ""
                 )
-                return f" (symlink{target})"
             if not row.changed and left_size == right_size:
                 return (
                     f" ({format_human_byte_size(left_size)})"
@@ -1408,12 +1406,11 @@ class CompareDetailsView(Vertical):
     @staticmethod
     def _compare_file_side_label(package_file: PackageFile) -> str:
         if package_file.is_symlink:
-            target = (
-                f" -> {package_file.link_target}"
+            return (
+                f"-> {package_file.link_target}"
                 if package_file.link_target is not None
-                else ""
+                else "unknown"
             )
-            return f"symlink{target}"
         if package_file.size_in_bytes is not None:
             return format_human_byte_size(package_file.size_in_bytes)
         return "unknown"

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -26,6 +26,7 @@ from pixi_browse.models import (
     CompareSelection,
     DependencyTab,
     FileTab,
+    PackageFile,
     VersionArtifactData,
     VersionCompareData,
 )
@@ -530,13 +531,8 @@ class VersionDetailsView(Vertical):
         if package_files:
             return tuple(
                 FileListEntry(
-                    label=(
-                        f"{self._displayed_file_path(package_file.path, tab)}"
-                        f" ({format_human_byte_size(package_file.size_in_bytes)})"
-                        if package_file.size_in_bytes is not None
-                        else self._displayed_file_path(package_file.path, tab)
-                    ),
-                    path=package_file.path,
+                    label=self._file_label(package_file, tab),
+                    path=None if package_file.is_symlink else package_file.path,
                     size_in_bytes=package_file.size_in_bytes,
                     sha256=package_file.sha256,
                 )
@@ -547,6 +543,20 @@ class VersionDetailsView(Vertical):
     @staticmethod
     def _displayed_file_path(path: str, tab: FileTab) -> str:
         return path.removeprefix("info/") if tab == "info" else path
+
+    @classmethod
+    def _file_label(cls, package_file: PackageFile, tab: FileTab) -> str:
+        path = cls._displayed_file_path(package_file.path, tab)
+        if package_file.is_symlink:
+            target = (
+                f" -> {package_file.link_target}"
+                if package_file.link_target is not None
+                else ""
+            )
+            return f"{path}{target} (symlink)"
+        if package_file.size_in_bytes is not None:
+            return f"{path} ({format_human_byte_size(package_file.size_in_bytes)})"
+        return path
 
     def _move_file_highlight(self, delta: int) -> None:
         option_list = self.query_one("#detail-option-list-2", DetailOptionList)
@@ -1351,36 +1361,62 @@ class CompareDetailsView(Vertical):
             row.right_file.size_in_bytes if row.right_file is not None else None
         )
         if row.left_file is not None and row.right_file is not None:
+            if (
+                not row.changed
+                and row.left_file.is_symlink
+                and row.right_file.is_symlink
+            ):
+                target = (
+                    f" -> {row.left_file.link_target}"
+                    if row.left_file.link_target is not None
+                    else ""
+                )
+                return f" (symlink{target})"
             if not row.changed and left_size == right_size:
                 return (
                     f" ({format_human_byte_size(left_size)})"
                     if left_size is not None
                     else ""
                 )
-            left_label = (
-                format_human_byte_size(left_size)
-                if left_size is not None
-                else "unknown"
-            )
-            right_label = (
-                format_human_byte_size(right_size)
-                if right_size is not None
-                else "unknown"
-            )
+            left_label = CompareDetailsView._compare_file_side_label(row.left_file)
+            right_label = CompareDetailsView._compare_file_side_label(row.right_file)
             return f" [L: {left_label} | R: {right_label}]"
         if row.left_file is not None:
+            if row.left_file.is_symlink:
+                return (
+                    " [left: "
+                    f"{CompareDetailsView._compare_file_side_label(row.left_file)}]"
+                )
             return (
                 f" [left: {format_human_byte_size(left_size)}]"
                 if left_size is not None
                 else " [left]"
             )
         if row.right_file is not None:
+            if row.right_file.is_symlink:
+                return (
+                    " [right: "
+                    f"{CompareDetailsView._compare_file_side_label(row.right_file)}]"
+                )
             return (
                 f" [right: {format_human_byte_size(right_size)}]"
                 if right_size is not None
                 else " [right]"
             )
         return ""
+
+    @staticmethod
+    def _compare_file_side_label(package_file: PackageFile) -> str:
+        if package_file.is_symlink:
+            target = (
+                f" -> {package_file.link_target}"
+                if package_file.link_target is not None
+                else ""
+            )
+            return f"symlink{target}"
+        if package_file.size_in_bytes is not None:
+            return format_human_byte_size(package_file.size_in_bytes)
+        return "unknown"
 
     def _move_file_highlight(self, delta: int) -> None:
         option_list = self.query_one("#compare-option-list-2", DetailOptionList)

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -2308,7 +2308,7 @@ def test_compare_file_rows_show_sizes_instead_of_sha256_values() -> None:
     assert "22222222" not in option
 
 
-def test_compare_symlinks_show_target_and_have_no_actions() -> None:
+def test_compare_symlinks_have_consistent_labels_and_no_actions() -> None:
     symlink = PackageFile(
         path="info/current",
         size_in_bytes=13,
@@ -2324,9 +2324,7 @@ def test_compare_symlinks_show_target_and_have_no_actions() -> None:
         right_file=symlink,
     )
 
-    assert CompareDetailsView._compare_file_suffix(row) == (
-        " (symlink -> recipe/meta.yaml)"
-    )
+    assert CompareDetailsView._compare_file_suffix(row) == " (symlink)"
     assert CondaMetadataTui._compare_file_action_options(row) == ()
 
     mixed_row = CompareFileRow(
@@ -2526,7 +2524,7 @@ def test_info_file_list_entries_use_archive_paths_and_sizes() -> None:
     assert [entry.label for entry in entries] == [
         "index.json (1.0 KiB)",
         "recipe/meta.yaml (1.5 KiB)",
-        "current -> recipe/meta.yaml (symlink)",
+        "current (symlink)",
     ]
     assert [entry.path for entry in entries] == [
         "info/index.json",

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -935,10 +935,19 @@ def test_get_package_paths_caches_archive_paths() -> None:
             ),
         ]
 
+    class _FakeEntry:
+        name = "lib/python3.13/site-packages/demo.py"
+        is_symlink = True
+        link_target = "demo.py"
+
     class _FakeArchive:
         async def paths_json(self) -> _FakePathsJson:
             calls.append("paths_json")
             return _FakePathsJson()
+
+        async def stream(self, section: str):
+            calls.append(section)
+            yield _FakeEntry()
 
     archive = cast(PackageArchive, _FakeArchive())
     paths = asyncio.run(loader.get_package_paths(preview_key, archive))
@@ -958,10 +967,11 @@ def test_get_package_paths_caches_archive_paths() -> None:
             None,
             True,
             "softlink",
+            "demo.py",
         ),
     ]
     assert cached_paths == paths
-    assert calls == ["paths_json"]
+    assert calls == ["paths_json", "pkg"]
 
 
 def test_get_info_files_streams_archive_info_section_with_sizes() -> None:
@@ -2308,7 +2318,7 @@ def test_compare_file_rows_show_sizes_instead_of_sha256_values() -> None:
     assert "22222222" not in option
 
 
-def test_compare_symlinks_have_consistent_labels_and_no_actions() -> None:
+def test_compare_symlinks_show_target_and_have_no_actions() -> None:
     symlink = PackageFile(
         path="info/current",
         size_in_bytes=13,
@@ -2324,7 +2334,9 @@ def test_compare_symlinks_have_consistent_labels_and_no_actions() -> None:
         right_file=symlink,
     )
 
-    assert CompareDetailsView._compare_file_suffix(row) == " (symlink)"
+    assert CompareDetailsView._compare_file_suffix(row) == (
+        " (symlink -> recipe/meta.yaml)"
+    )
     assert CondaMetadataTui._compare_file_action_options(row) == ()
 
     mixed_row = CompareFileRow(
@@ -2524,7 +2536,7 @@ def test_info_file_list_entries_use_archive_paths_and_sizes() -> None:
     assert [entry.label for entry in entries] == [
         "index.json (1.0 KiB)",
         "recipe/meta.yaml (1.5 KiB)",
-        "current (symlink)",
+        "current -> recipe/meta.yaml (symlink)",
     ]
     assert [entry.path for entry in entries] == [
         "info/index.json",

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -2334,9 +2334,7 @@ def test_compare_symlinks_show_target_and_have_no_actions() -> None:
         right_file=symlink,
     )
 
-    assert CompareDetailsView._compare_file_suffix(row) == (
-        " (symlink -> recipe/meta.yaml)"
-    )
+    assert CompareDetailsView._compare_file_suffix(row) == " -> recipe/meta.yaml"
     assert CondaMetadataTui._compare_file_action_options(row) == ()
 
     mixed_row = CompareFileRow(
@@ -2512,7 +2510,7 @@ def test_file_list_entry_uses_plain_file_path() -> None:
 
     assert entries[0].label == "site-packages/demo.py (1.5 KiB)"
     assert entries[0].path == "site-packages/demo.py"
-    assert entries[1].label == "bin/demo (symlink)"
+    assert entries[1].label == "bin/demo"
     assert entries[1].path is None
 
 
@@ -2536,7 +2534,7 @@ def test_info_file_list_entries_use_archive_paths_and_sizes() -> None:
     assert [entry.label for entry in entries] == [
         "index.json (1.0 KiB)",
         "recipe/meta.yaml (1.5 KiB)",
-        "current -> recipe/meta.yaml (symlink)",
+        "current -> recipe/meta.yaml",
     ]
     assert [entry.path for entry in entries] == [
         "info/index.json",

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -969,10 +969,19 @@ def test_get_info_files_streams_archive_info_section_with_sizes() -> None:
     calls: list[str] = []
 
     class _FakeEntry:
-        def __init__(self, name: str, size: int, *, is_file: bool = True) -> None:
+        def __init__(
+            self,
+            name: str,
+            size: int,
+            *,
+            is_file: bool = True,
+            link_target: str | None = None,
+        ) -> None:
             self.name = name
             self.size = size
             self.is_file = is_file
+            self.is_symlink = link_target is not None
+            self.link_target = link_target
 
     class _FakeArchive:
         async def stream(self, section: str):
@@ -980,6 +989,9 @@ def test_get_info_files_streams_archive_info_section_with_sizes() -> None:
             for entry in (
                 _FakeEntry("info/index.json", 42),
                 _FakeEntry("info/recipe", 0, is_file=False),
+                _FakeEntry(
+                    "info/current", 13, is_file=False, link_target="recipe/meta.yaml"
+                ),
                 _FakeEntry("info/paths.json", 1234),
             ):
                 yield entry
@@ -989,6 +1001,12 @@ def test_get_info_files_streams_archive_info_section_with_sizes() -> None:
 
     assert files == [
         PackageFile("info/index.json", 42),
+        PackageFile(
+            path="info/current",
+            size_in_bytes=13,
+            path_type="softlink",
+            link_target="recipe/meta.yaml",
+        ),
         PackageFile("info/paths.json", 1234),
     ]
     assert calls == ["info"]
@@ -2290,6 +2308,41 @@ def test_compare_file_rows_show_sizes_instead_of_sha256_values() -> None:
     assert "22222222" not in option
 
 
+def test_compare_symlinks_show_target_and_have_no_actions() -> None:
+    symlink = PackageFile(
+        path="info/current",
+        size_in_bytes=13,
+        path_type="softlink",
+        link_target="recipe/meta.yaml",
+    )
+    row = CompareFileRow(
+        label="current",
+        left="info/current",
+        right="info/current",
+        changed=False,
+        left_file=symlink,
+        right_file=symlink,
+    )
+
+    assert CompareDetailsView._compare_file_suffix(row) == (
+        " (symlink -> recipe/meta.yaml)"
+    )
+    assert CondaMetadataTui._compare_file_action_options(row) == ()
+
+    mixed_row = CompareFileRow(
+        label="current",
+        left="info/current",
+        right="info/current",
+        changed=True,
+        left_file=symlink,
+        right_file=PackageFile("info/current", 42),
+    )
+    assert CondaMetadataTui._compare_file_action_options(mixed_row) == (
+        FileActionOption(action="preview", label="Preview right", source="right"),
+        FileActionOption(action="download", label="Download right", source="right"),
+    )
+
+
 def test_unknown_compare_info_row_styles_only_marker_yellow() -> None:
     row = CompareFileRow(
         label="index.json",
@@ -2439,13 +2492,18 @@ def test_dependency_list_entry_unescapes_matchspec_text() -> None:
 def test_file_list_entry_uses_plain_file_path() -> None:
     view = VersionDetailsView()
     view._details = _make_artifact_data(
-        file_paths=(PackageFile("site-packages/demo.py", 1536),),
+        file_paths=(
+            PackageFile("site-packages/demo.py", 1536),
+            PackageFile("bin/demo", path_type="softlink"),
+        ),
     )
 
     entries = view._file_entries_for_details()
 
     assert entries[0].label == "site-packages/demo.py (1.5 KiB)"
     assert entries[0].path == "site-packages/demo.py"
+    assert entries[1].label == "bin/demo (symlink)"
+    assert entries[1].path is None
 
 
 def test_info_file_list_entries_use_archive_paths_and_sizes() -> None:
@@ -2454,6 +2512,12 @@ def test_info_file_list_entries_use_archive_paths_and_sizes() -> None:
         info_files=(
             PackageFile("info/index.json", 1024),
             PackageFile("info/recipe/meta.yaml", 1536),
+            PackageFile(
+                path="info/current",
+                size_in_bytes=13,
+                path_type="softlink",
+                link_target="recipe/meta.yaml",
+            ),
         ),
     )
 
@@ -2462,12 +2526,14 @@ def test_info_file_list_entries_use_archive_paths_and_sizes() -> None:
     assert [entry.label for entry in entries] == [
         "index.json (1.0 KiB)",
         "recipe/meta.yaml (1.5 KiB)",
+        "current -> recipe/meta.yaml (symlink)",
     ]
     assert [entry.path for entry in entries] == [
         "info/index.json",
         "info/recipe/meta.yaml",
+        None,
     ]
-    assert [entry.size_in_bytes for entry in entries] == [1024, 1536]
+    assert [entry.size_in_bytes for entry in entries] == [1024, 1536, 13]
 
 
 def test_on_key_bracket_shortcut_is_ignored_when_dependency_pane_is_inactive(


### PR DESCRIPTION
closes #69 

## Summary

- preserve symlink metadata while loading both `pkg/` and `info/` entries
- display symlinks consistently as `(symlink)` in package details and diff views
- prevent symlink entries from being previewed or downloaded
- compare known symlink targets without attempting to hash their contents

## Why

Symlink entries were previously treated like regular files, which made their presentation ambiguous and allowed unsupported preview/download actions. The package details and comparison views now identify them explicitly and keep those actions limited to regular files.

## User impact

Symlinks remain visible in file listings, but are clearly marked and cannot be opened or downloaded as if they were regular files.

## Validation

- `pixi run lint`
- `pixi run mypy pixi_browse`
- `pixi run pytest -q` (161 passed)