### PR TITLE
Sort subdirs by latest package version

### DIFF
--- a/pixi_browse/platform_utils.py
+++ b/pixi_browse/platform_utils.py
@@ -1,8 +1,24 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
+
 from rattler.platform import Platform
+from rattler.version import Version
 
 
 def platform_sort_key(platform: Platform) -> tuple[bool, str]:
     platform_name = str(platform)
     return (platform_name == "noarch", platform_name)
+
+
+def sort_subdirs_by_latest_version[VersionedT](
+    entries_by_subdir: Mapping[str, Sequence[VersionedT]],
+    version: Callable[[VersionedT], Version],
+) -> list[str]:
+    """Sort subdirs by their latest package version, then by name."""
+    subdirs = sorted(entries_by_subdir)
+    subdirs.sort(
+        key=lambda subdir: max(version(entry) for entry in entries_by_subdir[subdir]),
+        reverse=True,
+    )
+    return subdirs

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -22,6 +22,7 @@ from pixi_browse.models import (
     VersionArtifactData,
     VersionCompareData,
 )
+from pixi_browse.platform_utils import sort_subdirs_by_latest_version
 
 _SYNTAX_LEXERS_BY_SUFFIX: dict[str, str] = {
     ".bash": "bash",
@@ -258,9 +259,9 @@ def render_package_preview(
             reverse=True,
         )
 
-    sorted_subdirs = sorted(
+    sorted_subdirs = sort_subdirs_by_latest_version(
         grouped_by_subdir,
-        key=lambda subdir: (subdir == "noarch", subdir),
+        lambda record: record.version,
     )
 
     version_width = max(len(str(record.version)) for record in records)

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -41,7 +41,10 @@ from pixi_browse.models import (
     VersionRow,
     ViewMode,
 )
-from pixi_browse.platform_utils import platform_sort_key
+from pixi_browse.platform_utils import (
+    platform_sort_key,
+    sort_subdirs_by_latest_version,
+)
 from pixi_browse.rendering import (
     build_version_compare_data,
     format_human_byte_size,
@@ -1968,9 +1971,9 @@ class CondaMetadataTui(App[None]):
         grouped_versions: dict[str, list[VersionEntry]] = defaultdict(list)
         for entry in self._current_versions:
             grouped_versions[entry.subdir].append(entry)
-        self._version_subdirs = sorted(
+        self._version_subdirs = sort_subdirs_by_latest_version(
             grouped_versions,
-            key=lambda subdir: (subdir == "noarch", subdir),
+            lambda entry: entry.version,
         )
         self._versions_by_subdir = {
             subdir: grouped_versions[subdir] for subdir in self._version_subdirs

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -893,6 +893,32 @@ def test_render_package_preview_shows_version_selector_preview() -> None:
     assert "Dependencies" not in rendered
 
 
+def test_render_package_preview_orders_subdirs_by_latest_version_then_name() -> None:
+    records = [
+        _make_repo_data_record(version="1.33.1", subdir="osx-arm64"),
+        _make_repo_data_record(version="1.33.1", subdir="linux-64"),
+        _make_repo_data_record(version="1.34.0", subdir="noarch"),
+    ]
+
+    rendered = render_package_preview(
+        "demo",
+        records,
+        record_sort_key=lambda record: (
+            record.version,
+            record.build,
+            record.subdir,
+            record.build_number,
+        ),
+    )
+
+    headings = [
+        rendered.index("▾ noarch"),
+        rendered.index("▾ linux-64"),
+        rendered.index("▾ osx-arm64"),
+    ]
+    assert headings == sorted(headings)
+
+
 def test_get_package_paths_caches_archive_paths() -> None:
     loader = VersionDataLoader(client=cast(Client, object()))
     preview_key = ("demo", "1.2.3", "py313h123_0", 0, "noarch", "demo.conda")
@@ -1230,6 +1256,32 @@ def test_open_versions_keeps_focus_in_sidebar(monkeypatch) -> None:
 
     assert focused == []
     assert app._sidebar_title_text(selected=False).plain == "[0] Versions: demo"
+
+
+def test_open_versions_orders_subdirs_by_latest_version_then_name(monkeypatch) -> None:
+    app = CondaMetadataTui()
+
+    class _FakeOptionList:
+        highlighted = 0
+        scroll_y = 0.0
+
+    async def _fake_get_package_records(package_name: str) -> list[_Record]:
+        assert package_name == "demo"
+        return [
+            _Record(Version("1.33.1"), "build", 0, "osx-arm64", "osx.conda"),
+            _Record(Version("1.33.1"), "build", 0, "linux-64", "linux.conda"),
+            _Record(Version("1.34.0"), "build", 0, "noarch", "noarch.conda"),
+        ]
+
+    monkeypatch.setattr(app, "query_one", lambda *_args: _FakeOptionList())
+    monkeypatch.setattr(app, "_get_package_records", _fake_get_package_records)
+    monkeypatch.setattr(app, "_update_filter_indicator", lambda: None)
+    monkeypatch.setattr(app, "_update_versions_status", lambda: None)
+    monkeypatch.setattr(app, "_render_version_options", lambda: None)
+
+    asyncio.run(app._open_versions("demo"))
+
+    assert app._version_subdirs == ["noarch", "linux-64", "osx-arm64"]
 
 
 def test_open_versions_uses_matchspec_records_when_present(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- order package subdirectories by the newest package version they contain
- use the subdirectory name as an alphabetical tie-breaker
- apply the same ordering in both the package preview and version sidebar
- add regression coverage for the reported `noarch` ordering case

## Root cause

Subdirectories were sorted alphabetically with `noarch` always forced to the end, without considering the package versions available in each subdirectory. This caused a subdirectory containing the newest releases to appear below subdirectories containing only older releases.

## Impact

The subdirectory containing the newest release now appears first, so packages such as Polars show `noarch` above platform-specific subdirectories when that is where newer releases are published.

Fixes #75.

## Validation

- `pixi run lint`
- `pixi run pytest` (176 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Package previews now list platform subdirectories by their newest available version, with names used as a tie-breaker.
  - The version selector uses the same ordering for a more consistent browsing experience.

- **Tests**
  - Added coverage confirming consistent subdirectory ordering in package previews and the version selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->