### PR TITLE
Add direct conda artifact inspection and comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Explore packages, versions, dependencies, and more from any conda channel — ri
 - **Inspect versions** grouped by platform with collapsible sections
 - **View detailed metadata** including dependencies, license, checksums, build info, and timestamps
 - **Inspect package contents** — file listings and `about.json` extracted directly from artifacts
+- **Inspect local or remote artifacts** in both `.conda` and `.tar.bz2` formats
+- **Compare two artifacts directly** across metadata, dependencies, and files
 - **Clickable links** to source repositories, maintainer GitHub profiles, and provenance commits
 - **Download artifacts** directly to your working directory
 - **Vim-style keybindings** for fast keyboard-driven navigation
@@ -59,6 +61,13 @@ pixi-browse -m "numpy >=2"
 # Combine channel, platform, and MatchSpec filters
 pixi-browse -c https://prefix.dev/conda-forge -p linux-64 -m "python >=3.13"
 
+# Inspect a local or remote package artifact
+pixi-browse inspect ./package.conda
+pixi-browse inspect https://example.com/package.tar.bz2
+
+# Compare any combination of local and remote artifacts
+pixi-browse compare ./released.conda ./locally-built.conda
+
 # Show version
 pixi-browse --version
 ```
@@ -72,6 +81,13 @@ pixi-browse --version
 | `-m`, `--matchspec` | MatchSpec query to apply at startup                 |
 | `--version`         | Show version and exit                               |
 | `--help`            | Show help and exit                                  |
+
+### CLI Commands
+
+| Command              | Description                                                |
+| -------------------- | ---------------------------------------------------------- |
+| `inspect SOURCE`     | Inspect a local path or HTTP(S) package artifact URL       |
+| `compare LEFT RIGHT` | Compare two local or remote package artifacts side by side |
 
 ## Keybindings
 

--- a/pixi_browse/__main__.py
+++ b/pixi_browse/__main__.py
@@ -6,7 +6,8 @@ from rattler.match_spec import MatchSpec
 from rattler.platform import Platform
 
 from pixi_browse import __version__
-from pixi_browse.models import VersionEntry, VersionRow
+from pixi_browse.artifacts import InvalidArtifactSourceError, parse_artifact_source
+from pixi_browse.models import ArtifactSource, VersionEntry, VersionRow
 from pixi_browse.tui import CondaMetadataTui
 
 __all__ = [
@@ -33,6 +34,7 @@ cli = typer.Typer(
 
 @cli.callback(invoke_without_command=True)
 def run(
+    ctx: typer.Context,
     channel: str = typer.Option(
         "conda-forge",
         "--channel",
@@ -59,6 +61,8 @@ def run(
         help="Show version and exit.",
     ),
 ) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
     requested_platforms: list[Platform] | None = None
     requested_matchspec: MatchSpec | None = None
     if platform is not None:
@@ -80,6 +84,43 @@ def run(
         default_channel=channel,
         default_platforms=requested_platforms,
         default_matchspec=requested_matchspec,
+    ).run()
+
+
+def _parse_source(value: str, *, argument_name: str) -> ArtifactSource:
+    try:
+        return parse_artifact_source(value)
+    except InvalidArtifactSourceError as exc:
+        raise typer.BadParameter(str(exc), param_hint=argument_name) from exc
+
+
+@cli.command("inspect")
+def inspect_artifact(
+    source: str = typer.Argument(
+        ...,
+        help="Local path or HTTP(S) URL to a .conda or .tar.bz2 artifact.",
+    ),
+) -> None:
+    artifact_source = _parse_source(source, argument_name="SOURCE")
+    CondaMetadataTui(artifact_sources=[artifact_source]).run()
+
+
+@cli.command("compare")
+def compare_artifacts(
+    left: str = typer.Argument(
+        ...,
+        help="Local path or HTTP(S) URL for the left artifact.",
+    ),
+    right: str = typer.Argument(
+        ...,
+        help="Local path or HTTP(S) URL for the right artifact.",
+    ),
+) -> None:
+    left_source = _parse_source(left, argument_name="LEFT")
+    right_source = _parse_source(right, argument_name="RIGHT")
+    CondaMetadataTui(
+        artifact_sources=[left_source, right_source],
+        compare_artifacts=True,
     ).run()
 
 

--- a/pixi_browse/artifacts.py
+++ b/pixi_browse/artifacts.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import urlparse
 
+from rattler.package import IndexJson
+from rattler.repo_data import PackageRecord
+from rattler.version import VersionWithSource
+
 from pixi_browse.models import (
     ArtifactSource,
     LocalArtifactSource,
@@ -12,6 +16,34 @@ from pixi_browse.models import (
 
 class InvalidArtifactSourceError(ValueError):
     pass
+
+
+def into_package_record(
+    value: IndexJson | PackageRecord,
+) -> PackageRecord:
+    if isinstance(value, PackageRecord):
+        return value
+
+    record = PackageRecord(
+        name=value.name,
+        # IndexJson exposes Version even though PackageRecord requires
+        # VersionWithSource, so convert explicitly at this boundary.
+        version=VersionWithSource(str(value.version)),
+        build=value.build,
+        build_number=value.build_number,
+        subdir=value.subdir or "unknown",
+        arch=value.arch,
+        platform=value.platform,
+        depends=list(value.depends),
+        constrains=list(value.constrains),
+        license=value.license,
+        license_family=value.license_family,
+    )
+
+    record.timestamp = value.timestamp
+    record.features = value.features
+    record.track_features = list(value.track_features)
+    return record
 
 
 def parse_artifact_source(value: str) -> ArtifactSource:

--- a/pixi_browse/artifacts.py
+++ b/pixi_browse/artifacts.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+from pixi_browse.models import (
+    ArtifactSource,
+    LocalArtifactSource,
+    RemoteArtifactSource,
+)
+
+
+class InvalidArtifactSourceError(ValueError):
+    pass
+
+
+def parse_artifact_source(value: str) -> ArtifactSource:
+    candidate = value.strip()
+    if not candidate:
+        raise InvalidArtifactSourceError("Artifact source cannot be empty.")
+
+    parsed = urlparse(candidate)
+    if parsed.scheme in {"http", "https"}:
+        if not parsed.netloc:
+            raise InvalidArtifactSourceError(f"Invalid artifact URL: {candidate}")
+        return RemoteArtifactSource(candidate)
+    if parsed.scheme:
+        raise InvalidArtifactSourceError(
+            f"Unsupported artifact URL scheme {parsed.scheme!r}; use HTTP(S) or a path."
+        )
+
+    path = Path(candidate).expanduser().resolve()
+    if not path.exists():
+        raise InvalidArtifactSourceError(f"Artifact does not exist: {path}")
+    if not path.is_file():
+        raise InvalidArtifactSourceError(f"Artifact is not a file: {path}")
+    return LocalArtifactSource(path)

--- a/pixi_browse/models.py
+++ b/pixi_browse/models.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
 from typing import Literal
+from urllib.parse import unquote, urlparse
 
 from rattler.package import RunExportsJson
 from rattler.version import Version
@@ -9,10 +12,76 @@ from rattler.version import Version
 ViewMode = Literal["packages", "versions", "platforms"]
 VersionRowKind = Literal["back", "section", "entry", "empty"]
 VersionPreviewKey = tuple[str, str, str, int, str, str]
+ArtifactCacheKey = VersionPreviewKey | str
 DependencyTab = Literal["dependencies", "constraints", "run_exports"]
 FileTab = Literal["pkg", "info"]
 PackageFilePathType = Literal["hardlink", "softlink", "directory"]
 MetadataRow = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class LocalArtifactSource:
+    path: Path
+
+    @property
+    def cache_key(self) -> str:
+        return f"path:{self.path}"
+
+    @property
+    def display_name(self) -> str:
+        return self.path.name
+
+    @property
+    def location(self) -> str:
+        return str(self.path)
+
+
+@dataclass(frozen=True)
+class RemoteArtifactSource:
+    url: str
+
+    @property
+    def cache_key(self) -> str:
+        return f"url:{self.url}"
+
+    @property
+    def display_name(self) -> str:
+        return Path(unquote(urlparse(self.url).path)).name or self.url
+
+    @property
+    def location(self) -> str:
+        return self.url
+
+
+ArtifactSource = LocalArtifactSource | RemoteArtifactSource
+
+
+@dataclass(frozen=True)
+class ArtifactMetadata:
+    name: str
+    version: Version
+    build: str
+    build_number: int
+    subdir: str
+    file_name: str
+    source: ArtifactSource
+    dependencies: tuple[str, ...] = ()
+    constraints: tuple[str, ...] = ()
+    channel: str | None = None
+    size: int | None = None
+    timestamp: datetime | None = None
+    license: str | None = None
+    license_family: str | None = None
+    arch: str | None = None
+    platform: str | None = None
+    noarch: str | None = None
+    features: str | None = None
+    track_features: tuple[str, ...] = ()
+    python_site_packages_path: str | None = None
+    md5: bytes | None = None
+    sha256: bytes | None = None
+    legacy_bz2_md5: bytes | None = None
+    legacy_bz2_size: int | None = None
 
 
 @dataclass(frozen=True)
@@ -67,6 +136,7 @@ class VersionArtifactData:
 class CompareSelection:
     package_name: str
     entry: VersionEntry
+    source: ArtifactSource | None = None
 
 
 @dataclass(frozen=True)

--- a/pixi_browse/models.py
+++ b/pixi_browse/models.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import Literal
 from urllib.parse import unquote, urlparse
 
 from rattler.package import RunExportsJson
+from rattler.repo_data import PackageRecord
 from rattler.version import Version
 
 ViewMode = Literal["packages", "versions", "platforms"]
@@ -57,31 +57,12 @@ ArtifactSource = LocalArtifactSource | RemoteArtifactSource
 
 
 @dataclass(frozen=True)
-class ArtifactMetadata:
-    name: str
-    version: Version
-    build: str
-    build_number: int
-    subdir: str
-    file_name: str
+class ArtifactDescriptor:
+    record: PackageRecord
     source: ArtifactSource
-    dependencies: tuple[str, ...] = ()
-    constraints: tuple[str, ...] = ()
+    file_name: str
     channel: str | None = None
-    size: int | None = None
-    timestamp: datetime | None = None
-    license: str | None = None
-    license_family: str | None = None
-    arch: str | None = None
-    platform: str | None = None
-    noarch: str | None = None
-    features: str | None = None
-    track_features: tuple[str, ...] = ()
-    python_site_packages_path: str | None = None
-    md5: bytes | None = None
-    sha256: bytes | None = None
-    legacy_bz2_md5: bytes | None = None
-    legacy_bz2_size: int | None = None
+    package_name: str | None = None
 
 
 @dataclass(frozen=True)

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -13,8 +13,9 @@ from rattler.repo_data import RepoDataRecord
 from rattler.version import VersionWithSource
 from rich.markup import escape
 
+from pixi_browse.artifacts import into_package_record
 from pixi_browse.models import (
-    ArtifactMetadata,
+    ArtifactDescriptor,
     CompareFileRow,
     CompareRow,
     CompareSelection,
@@ -326,7 +327,7 @@ def _format_plain_run_exports_lines(run_exports: RunExportsJson | None) -> list[
 
 
 def _metadata_rows_for_artifact(
-    metadata: ArtifactMetadata,
+    artifact: ArtifactDescriptor,
     *,
     clickable: bool = False,
     repository_urls: Sequence[str] = (),
@@ -337,35 +338,36 @@ def _metadata_rows_for_artifact(
     provenance_sha: str | None = None,
     rattler_build_version: str | None = None,
 ) -> tuple[MetadataRow, ...]:
+    record = artifact.record
     metadata_rows: list[MetadataRow] = [
-        ("Package", metadata.name),
-        ("Name", metadata.name),
-        ("Version", format_record_value(metadata.version)),
-        ("Build", format_record_value(metadata.build)),
-        ("Build Number", format_record_value(metadata.build_number)),
-        ("Subdir", format_record_value(metadata.subdir)),
-        ("File Name", format_record_value(metadata.file_name)),
-        ("Channel", format_record_value(metadata.channel)),
-        ("Size", format_byte_size(metadata.size)),
-        ("Timestamp", format_record_value(metadata.timestamp)),
-        ("License", format_record_value(metadata.license)),
-        ("License Family", format_record_value(metadata.license_family)),
-        ("Arch", format_record_value(metadata.arch)),
-        ("Platform", format_record_value(metadata.platform)),
-        ("NoArch", format_record_value(metadata.noarch)),
-        ("Features", format_record_value(metadata.features)),
-        ("Track Features", format_record_value(metadata.track_features)),
+        ("Package", artifact.package_name or record.name.normalized),
+        ("Name", record.name.source),
+        ("Version", format_record_value(record.version)),
+        ("Build", format_record_value(record.build)),
+        ("Build Number", format_record_value(record.build_number)),
+        ("Subdir", format_record_value(record.subdir)),
+        ("File Name", format_record_value(artifact.file_name)),
+        ("Channel", format_record_value(artifact.channel)),
+        ("Size", format_byte_size(record.size)),
+        ("Timestamp", format_record_value(record.timestamp)),
+        ("License", format_record_value(record.license)),
+        ("License Family", format_record_value(record.license_family)),
+        ("Arch", format_record_value(record.arch)),
+        ("Platform", format_record_value(record.platform)),
+        ("NoArch", format_record_value(record.noarch)),
+        ("Features", format_record_value(record.features)),
+        ("Track Features", format_record_value(record.track_features)),
         (
             "Python Site-Packages",
-            format_record_value(metadata.python_site_packages_path),
+            format_record_value(record.python_site_packages_path),
         ),
-        ("MD5", format_record_value(metadata.md5)),
-        ("SHA256", format_record_value(metadata.sha256)),
-        ("Legacy .tar.bz2 MD5", format_record_value(metadata.legacy_bz2_md5)),
-        ("Legacy .tar.bz2 Size", format_byte_size(metadata.legacy_bz2_size)),
+        ("MD5", format_record_value(record.md5)),
+        ("SHA256", format_record_value(record.sha256)),
+        ("Legacy .tar.bz2 MD5", format_record_value(record.legacy_bz2_md5)),
+        ("Legacy .tar.bz2 Size", format_byte_size(record.legacy_bz2_size)),
         (
             "Package URL",
-            _format_url_value(metadata.source.location, clickable=clickable),
+            _format_url_value(artifact.source.location, clickable=clickable),
         ),
     ]
     if repository_urls:
@@ -409,34 +411,15 @@ def _metadata_rows_for_artifact(
     return tuple(metadata_rows)
 
 
-def _artifact_metadata_from_record(
+def _artifact_descriptor_from_record(
     package_name: str, record: RepoDataRecord
-) -> ArtifactMetadata:
-    return ArtifactMetadata(
-        name=package_name,
-        version=record.version,
-        build=record.build,
-        build_number=record.build_number,
-        subdir=record.subdir,
+) -> ArtifactDescriptor:
+    return ArtifactDescriptor(
+        record=into_package_record(record),
         file_name=record.file_name,
         source=RemoteArtifactSource(str(record.url)),
-        dependencies=tuple(str(dependency) for dependency in record.depends or ()),
-        constraints=tuple(str(constraint) for constraint in record.constrains or ()),
         channel=None if record.channel is None else str(record.channel),
-        size=record.size,
-        timestamp=record.timestamp,
-        license=record.license,
-        license_family=record.license_family,
-        arch=record.arch,
-        platform=record.platform,
-        noarch=None if record.noarch is None else str(record.noarch),
-        features=record.features,
-        track_features=tuple(record.track_features or ()),
-        python_site_packages_path=record.python_site_packages_path,
-        md5=record.md5,
-        sha256=record.sha256,
-        legacy_bz2_md5=record.legacy_bz2_md5,
-        legacy_bz2_size=record.legacy_bz2_size,
+        package_name=package_name,
     )
 
 
@@ -456,7 +439,7 @@ def build_version_artifact_data(
     run_exports: RunExportsJson | None = None,
 ) -> VersionArtifactData:
     return build_artifact_data(
-        _artifact_metadata_from_record(package_name, record),
+        _artifact_descriptor_from_record(package_name, record),
         package_paths=package_paths,
         info_files=info_files,
         repository_urls=repository_urls,
@@ -471,7 +454,7 @@ def build_version_artifact_data(
 
 
 def build_artifact_data(
-    metadata: ArtifactMetadata,
+    artifact: ArtifactDescriptor,
     *,
     package_paths: Sequence[PackageFile] = (),
     info_files: Sequence[PackageFile] = (),
@@ -486,7 +469,7 @@ def build_artifact_data(
 ) -> VersionArtifactData:
     return VersionArtifactData(
         metadata_rows=_metadata_rows_for_artifact(
-            metadata,
+            artifact,
             repository_urls=repository_urls,
             documentation_urls=documentation_urls,
             homepage_urls=homepage_urls,
@@ -495,9 +478,9 @@ def build_artifact_data(
             provenance_sha=provenance_sha,
             rattler_build_version=rattler_build_version,
         ),
-        dependencies=metadata.dependencies,
-        constraints=metadata.constraints,
-        package_url=metadata.source.location,
+        dependencies=tuple(str(dependency) for dependency in artifact.record.depends),
+        constraints=tuple(str(constraint) for constraint in artifact.record.constrains),
+        package_url=artifact.source.location,
         file_paths=tuple(package_paths),
         info_files=tuple(info_files),
         run_exports=run_exports,

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -14,11 +14,13 @@ from rattler.version import VersionWithSource
 from rich.markup import escape
 
 from pixi_browse.models import (
+    ArtifactMetadata,
     CompareFileRow,
     CompareRow,
     CompareSelection,
     MetadataRow,
     PackageFile,
+    RemoteArtifactSource,
     VersionArtifactData,
     VersionCompareData,
 )
@@ -323,9 +325,8 @@ def _format_plain_run_exports_lines(run_exports: RunExportsJson | None) -> list[
     return lines
 
 
-def _metadata_rows_for_record(
-    package_name: str,
-    record: RepoDataRecord,
+def _metadata_rows_for_artifact(
+    metadata: ArtifactMetadata,
     *,
     clickable: bool = False,
     repository_urls: Sequence[str] = (),
@@ -337,32 +338,35 @@ def _metadata_rows_for_record(
     rattler_build_version: str | None = None,
 ) -> tuple[MetadataRow, ...]:
     metadata_rows: list[MetadataRow] = [
-        ("Package", package_name),
-        ("Name", record.name.source),
-        ("Version", format_record_value(record.version)),
-        ("Build", format_record_value(record.build)),
-        ("Build Number", format_record_value(record.build_number)),
-        ("Subdir", format_record_value(record.subdir)),
-        ("File Name", format_record_value(record.file_name)),
-        ("Channel", format_record_value(record.channel)),
-        ("Size", format_byte_size(record.size)),
-        ("Timestamp", format_record_value(record.timestamp)),
-        ("License", format_record_value(record.license)),
-        ("License Family", format_record_value(record.license_family)),
-        ("Arch", format_record_value(record.arch)),
-        ("Platform", format_record_value(record.platform)),
-        ("NoArch", format_record_value(record.noarch)),
-        ("Features", format_record_value(record.features)),
-        ("Track Features", format_record_value(record.track_features)),
+        ("Package", metadata.name),
+        ("Name", metadata.name),
+        ("Version", format_record_value(metadata.version)),
+        ("Build", format_record_value(metadata.build)),
+        ("Build Number", format_record_value(metadata.build_number)),
+        ("Subdir", format_record_value(metadata.subdir)),
+        ("File Name", format_record_value(metadata.file_name)),
+        ("Channel", format_record_value(metadata.channel)),
+        ("Size", format_byte_size(metadata.size)),
+        ("Timestamp", format_record_value(metadata.timestamp)),
+        ("License", format_record_value(metadata.license)),
+        ("License Family", format_record_value(metadata.license_family)),
+        ("Arch", format_record_value(metadata.arch)),
+        ("Platform", format_record_value(metadata.platform)),
+        ("NoArch", format_record_value(metadata.noarch)),
+        ("Features", format_record_value(metadata.features)),
+        ("Track Features", format_record_value(metadata.track_features)),
         (
             "Python Site-Packages",
-            format_record_value(record.python_site_packages_path),
+            format_record_value(metadata.python_site_packages_path),
         ),
-        ("MD5", format_record_value(record.md5)),
-        ("SHA256", format_record_value(record.sha256)),
-        ("Legacy .tar.bz2 MD5", format_record_value(record.legacy_bz2_md5)),
-        ("Legacy .tar.bz2 Size", format_byte_size(record.legacy_bz2_size)),
-        ("Package URL", _format_url_value(str(record.url), clickable=clickable)),
+        ("MD5", format_record_value(metadata.md5)),
+        ("SHA256", format_record_value(metadata.sha256)),
+        ("Legacy .tar.bz2 MD5", format_record_value(metadata.legacy_bz2_md5)),
+        ("Legacy .tar.bz2 Size", format_byte_size(metadata.legacy_bz2_size)),
+        (
+            "Package URL",
+            _format_url_value(metadata.source.location, clickable=clickable),
+        ),
     ]
     if repository_urls:
         metadata_rows.append(
@@ -405,6 +409,37 @@ def _metadata_rows_for_record(
     return tuple(metadata_rows)
 
 
+def _artifact_metadata_from_record(
+    package_name: str, record: RepoDataRecord
+) -> ArtifactMetadata:
+    return ArtifactMetadata(
+        name=package_name,
+        version=record.version,
+        build=record.build,
+        build_number=record.build_number,
+        subdir=record.subdir,
+        file_name=record.file_name,
+        source=RemoteArtifactSource(str(record.url)),
+        dependencies=tuple(str(dependency) for dependency in record.depends or ()),
+        constraints=tuple(str(constraint) for constraint in record.constrains or ()),
+        channel=None if record.channel is None else str(record.channel),
+        size=record.size,
+        timestamp=record.timestamp,
+        license=record.license,
+        license_family=record.license_family,
+        arch=record.arch,
+        platform=record.platform,
+        noarch=None if record.noarch is None else str(record.noarch),
+        features=record.features,
+        track_features=tuple(record.track_features or ()),
+        python_site_packages_path=record.python_site_packages_path,
+        md5=record.md5,
+        sha256=record.sha256,
+        legacy_bz2_md5=record.legacy_bz2_md5,
+        legacy_bz2_size=record.legacy_bz2_size,
+    )
+
+
 def build_version_artifact_data(
     package_name: str,
     record: RepoDataRecord,
@@ -420,10 +455,38 @@ def build_version_artifact_data(
     rattler_build_version: str | None = None,
     run_exports: RunExportsJson | None = None,
 ) -> VersionArtifactData:
+    return build_artifact_data(
+        _artifact_metadata_from_record(package_name, record),
+        package_paths=package_paths,
+        info_files=info_files,
+        repository_urls=repository_urls,
+        documentation_urls=documentation_urls,
+        homepage_urls=homepage_urls,
+        recipe_maintainers=recipe_maintainers,
+        provenance_remote_url=provenance_remote_url,
+        provenance_sha=provenance_sha,
+        rattler_build_version=rattler_build_version,
+        run_exports=run_exports,
+    )
+
+
+def build_artifact_data(
+    metadata: ArtifactMetadata,
+    *,
+    package_paths: Sequence[PackageFile] = (),
+    info_files: Sequence[PackageFile] = (),
+    repository_urls: Sequence[str] = (),
+    documentation_urls: Sequence[str] = (),
+    homepage_urls: Sequence[str] = (),
+    recipe_maintainers: Sequence[str] = (),
+    provenance_remote_url: str | None = None,
+    provenance_sha: str | None = None,
+    rattler_build_version: str | None = None,
+    run_exports: RunExportsJson | None = None,
+) -> VersionArtifactData:
     return VersionArtifactData(
-        metadata_rows=_metadata_rows_for_record(
-            package_name,
-            record,
+        metadata_rows=_metadata_rows_for_artifact(
+            metadata,
             repository_urls=repository_urls,
             documentation_urls=documentation_urls,
             homepage_urls=homepage_urls,
@@ -432,9 +495,9 @@ def build_version_artifact_data(
             provenance_sha=provenance_sha,
             rattler_build_version=rattler_build_version,
         ),
-        dependencies=tuple(str(dependency) for dependency in record.depends or ()),
-        constraints=tuple(str(constraint) for constraint in record.constrains or ()),
-        package_url=str(record.url),
+        dependencies=metadata.dependencies,
+        constraints=metadata.constraints,
+        package_url=metadata.source.location,
         file_paths=tuple(package_paths),
         info_files=tuple(info_files),
         run_exports=run_exports,

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -218,7 +218,7 @@ class CondaMetadataTui(App[None]):
         self._show_direct_artifact(artifacts[0])
 
     def _show_direct_artifact(self, artifact: LoadedArtifact) -> None:
-        package_name = artifact.metadata.name
+        package_name = artifact.descriptor.record.name.normalized
         preview_key = self._version_preview_key(package_name, artifact.entry)
         self._direct_artifacts[preview_key] = artifact
         self._version_archive_cache[preview_key] = artifact.archive
@@ -244,12 +244,12 @@ class CondaMetadataTui(App[None]):
         self, left: LoadedArtifact, right: LoadedArtifact
     ) -> None:
         left_selection = CompareSelection(
-            package_name=left.metadata.name,
+            package_name=left.descriptor.record.name.normalized,
             entry=left.entry,
             source=left.source,
         )
         right_selection = CompareSelection(
-            package_name=right.metadata.name,
+            package_name=right.descriptor.record.name.normalized,
             entry=right.entry,
             source=right.source,
         )

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -953,21 +953,26 @@ class CondaMetadataTui(App[None]):
                 ("Esc", "Back or close current overlay"),
             ],
         )
-        app_rows = [
-            ("?", "Show this help"),
-            ("/", "Start package filter"),
-            ("p", "Open platform selector"),
-            ("c", "Edit channel"),
-            ("C", "Compare selected artifact in versions view"),
-        ]
-        if self._can_query_matchspec():
-            app_rows.append(("m", "Query MatchSpec"))
-        app_rows.extend(
-            [
-                ("d", "Download selected artifact in versions view"),
-                ("q", "Quit"),
-            ]
-        )
+        app_rows = [("?", "Show this help")]
+        if self._artifact_sources:
+            app_rows.extend(
+                [
+                    ("d", "Download selected artifact in versions view"),
+                    ("q", "Quit"),
+                ]
+            )
+        else:
+            app_rows.extend(
+                [
+                    ("/", "Start package filter"),
+                    ("p", "Open platform selector"),
+                    ("c", "Edit channel"),
+                    ("C", "Compare selected artifact in versions view"),
+                    ("m", "Query MatchSpec"),
+                    ("d", "Download selected artifact in versions view"),
+                    ("q", "Quit"),
+                ]
+            )
         app = self._format_help_section("App", app_rows)
         return "\n".join([*navigation, "", *app])
 
@@ -2385,6 +2390,8 @@ class CondaMetadataTui(App[None]):
         self._open_platform_selector()
 
     def action_channel_key_c(self) -> None:
+        if self._artifact_sources:
+            return
         if self._channel_edit_mode:
             self._append_channel_char("c")
             return
@@ -2396,6 +2403,8 @@ class CondaMetadataTui(App[None]):
         self._update_filter_indicator()
 
     def action_compare_key_c(self) -> None:
+        if self._artifact_sources:
+            return
         if self._channel_edit_mode:
             self._append_channel_char("C")
             return

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -822,6 +822,9 @@ class CondaMetadataTui(App[None]):
     def _selected_dependency_matchspec(self) -> str | None:
         return self.query_one("#main-panel", MainPanel).selected_dependency_matchspec()
 
+    def _can_query_matchspec(self) -> bool:
+        return not self._artifact_sources
+
     def _dependency_matchspec_at(self, index: int) -> str | None:
         return self.query_one("#main-panel", MainPanel).dependency_matchspec_at(index)
 
@@ -950,19 +953,22 @@ class CondaMetadataTui(App[None]):
                 ("Esc", "Back or close current overlay"),
             ],
         )
-        app = self._format_help_section(
-            "App",
+        app_rows = [
+            ("?", "Show this help"),
+            ("/", "Start package filter"),
+            ("p", "Open platform selector"),
+            ("c", "Edit channel"),
+            ("C", "Compare selected artifact in versions view"),
+        ]
+        if self._can_query_matchspec():
+            app_rows.append(("m", "Query MatchSpec"))
+        app_rows.extend(
             [
-                ("?", "Show this help"),
-                ("/", "Start package filter"),
-                ("p", "Open platform selector"),
-                ("c", "Edit channel"),
-                ("C", "Compare selected artifact in versions view"),
-                ("m", "Query MatchSpec"),
                 ("d", "Download selected artifact in versions view"),
                 ("q", "Quit"),
-            ],
+            ]
         )
+        app = self._format_help_section("App", app_rows)
         return "\n".join([*navigation, "", *app])
 
     @staticmethod
@@ -2448,7 +2454,11 @@ class CondaMetadataTui(App[None]):
         )
 
     def action_matchspec_key_m(self) -> None:
-        if self._channel_edit_mode or self._filter_mode:
+        if (
+            not self._can_query_matchspec()
+            or self._channel_edit_mode
+            or self._filter_mode
+        ):
             return
 
         self._open_matchspec_screen(self._matchspec_query)
@@ -2630,6 +2640,9 @@ class CondaMetadataTui(App[None]):
         ):
             main_panel = self.query_one("#main-panel", MainPanel)
             if main_panel.dependency_section_is_active():
+                if not self._can_query_matchspec():
+                    event.stop()
+                    return
                 matchspec = self._selected_dependency_matchspec()
                 if matchspec is not None:
                     self._defer_matchspec_screen(matchspec)
@@ -2928,6 +2941,8 @@ class CondaMetadataTui(App[None]):
         self._sidebar_selection_by_keyboard = False
 
         if event.option_list.id == "detail-option-list-1":
+            if not self._can_query_matchspec():
+                return
             matchspec = self._dependency_matchspec_at(event.option_index)
             if matchspec is None:
                 return

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import shutil
 import webbrowser
 from collections import defaultdict
 from collections.abc import Callable, Iterable
@@ -30,10 +32,13 @@ from textual.widgets import OptionList, Static
 
 from pixi_browse import __version__
 from pixi_browse.models import (
+    ArtifactCacheKey,
+    ArtifactSource,
     CompareFileRow,
     CompareSelection,
     DependencyTab,
     FileTab,
+    LocalArtifactSource,
     PackageFile,
     VersionArtifactData,
     VersionEntry,
@@ -63,7 +68,7 @@ from pixi_browse.repodata import (
 from pixi_browse.search import fuzzy_score
 
 from .state import ChannelStateSnapshot
-from .version_loader import VersionDataLoader
+from .version_loader import LoadedArtifact, VersionDataLoader
 from .widgets import (
     ACTIVE_SECTION_TITLE_STYLE,
     DEPENDENCY_TABS,
@@ -108,10 +113,17 @@ class CondaMetadataTui(App[None]):
         default_channel: str = "conda-forge",
         default_platforms: Iterable[Platform] | None = None,
         default_matchspec: MatchSpec | None = None,
+        artifact_sources: Iterable[ArtifactSource] = (),
+        compare_artifacts: bool = False,
     ) -> None:
         super().__init__()
         channel_name = default_channel.strip() or "conda-forge"
         selected_platforms = set(default_platforms or [])
+        resolved_artifact_sources = tuple(artifact_sources)
+        if compare_artifacts and len(resolved_artifact_sources) != 2:
+            raise ValueError("Artifact comparison requires exactly two sources.")
+        if not compare_artifacts and len(resolved_artifact_sources) > 1:
+            raise ValueError("Artifact inspection accepts exactly one source.")
         self.theme = "ansi-dark"
         self._client = Client.default_client(user_agent=f"pixi-browse/{__version__}")
 
@@ -158,6 +170,9 @@ class CondaMetadataTui(App[None]):
         self._selected_pane: Literal["sidebar", "main"] = "sidebar"
         self._compare_selection: CompareSelection | None = None
         self._compare_screen_open = False
+        self._artifact_sources = resolved_artifact_sources
+        self._compare_artifacts_on_startup = compare_artifacts
+        self._direct_artifacts: dict[VersionPreviewKey, LoadedArtifact] = {}
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="body"):
@@ -172,9 +187,81 @@ class CondaMetadataTui(App[None]):
         package_list.disabled = True
         package_list.focus()
         self._update_filter_indicator()
+        if self._artifact_sources:
+            await self._load_artifact_sources()
+            return
         loaded = await self._load_packages()
         if loaded and self._startup_matchspec is not None:
             await self._apply_matchspec_query(self._startup_matchspec)
+
+    async def _load_artifact_sources(self) -> None:
+        status = self.query_one("#status", Static)
+        status.update("Loading package artifact metadata...")
+        try:
+            artifacts = [
+                await self._version_loader.load_artifact_source(source)
+                for source in self._artifact_sources
+            ]
+        except Exception as exc:
+            status.update(f"Failed to load artifact: {exc!s}")
+            self._show_main_placeholder(
+                f"# Unable to load artifact\n\n{escape(str(exc))}"
+            )
+            return
+
+        if self._compare_artifacts_on_startup:
+            assert len(artifacts) == 2
+            await self._open_direct_compare(artifacts[0], artifacts[1])
+            return
+
+        assert len(artifacts) == 1
+        self._show_direct_artifact(artifacts[0])
+
+    def _show_direct_artifact(self, artifact: LoadedArtifact) -> None:
+        package_name = artifact.metadata.name
+        preview_key = self._version_preview_key(package_name, artifact.entry)
+        self._direct_artifacts[preview_key] = artifact
+        self._version_archive_cache[preview_key] = artifact.archive
+        self._version_artifact_data_cache[preview_key] = artifact.data
+        self._selected_package = package_name
+        self._current_versions = [artifact.entry]
+        self._version_rows = [VersionRow(kind="entry", entry=artifact.entry)]
+        self._mode = "versions"
+
+        package_list = self.query_one("#sidebar-list", OptionList)
+        package_list.clear_options()
+        package_list.add_option(artifact.source.display_name)
+        package_list.highlighted = 0
+        package_list.disabled = False
+        self._show_version_details(artifact.data)
+        self._previewed_version_key = preview_key
+        self._pending_preview_version_key = preview_key
+        self._update_filter_indicator()
+        self._update_versions_status()
+        self._focus_main_panel()
+
+    async def _open_direct_compare(
+        self, left: LoadedArtifact, right: LoadedArtifact
+    ) -> None:
+        left_selection = CompareSelection(
+            package_name=left.metadata.name,
+            entry=left.entry,
+            source=left.source,
+        )
+        right_selection = CompareSelection(
+            package_name=right.metadata.name,
+            entry=right.entry,
+            source=right.source,
+        )
+        compare_data = build_version_compare_data(
+            left_selection,
+            left.data,
+            right_selection,
+            right.data,
+        )
+        self._compare_screen_open = True
+        self.query_one("#footer", Static).update(self._footer_text())
+        self.push_screen(CompareScreen(compare_data), lambda _result: self.exit())
 
     async def _load_packages(self) -> bool:
         status = self.query_one("#status", Static)
@@ -265,6 +352,17 @@ class CondaMetadataTui(App[None]):
 
     def _render_version_options(self, *, preserve_position: bool = False) -> None:
         package_list = self.query_one("#sidebar-list", OptionList)
+        if self._artifact_sources and not self._compare_artifacts_on_startup:
+            previous_scroll_y = package_list.scroll_y
+            package_list.clear_options()
+            artifact = next(iter(self._direct_artifacts.values()), None)
+            if artifact is not None:
+                package_list.add_option(artifact.source.display_name)
+                self._version_rows = [VersionRow(kind="entry", entry=artifact.entry)]
+                package_list.highlighted = 0
+                if preserve_position:
+                    package_list.scroll_to(y=previous_scroll_y, animate=False)
+            return
         previous_highlight = package_list.highlighted
         previous_scroll_y = package_list.scroll_y
         package_list.clear_options()
@@ -328,6 +426,9 @@ class CondaMetadataTui(App[None]):
             package_list.scroll_to(y=previous_scroll_y, animate=False)
 
     def _update_versions_status(self) -> None:
+        if self._artifact_sources and not self._compare_artifacts_on_startup:
+            self.query_one("#status", Static).update("Standalone package artifact.")
+            return
         self.query_one("#status", Static).update(
             f"{len(self._current_versions):,} entries across "
             f"{len(self._version_subdirs)} platform{'s' if len(self._version_subdirs) > 1 else ''}."
@@ -938,11 +1039,16 @@ class CondaMetadataTui(App[None]):
     @staticmethod
     def _compare_selection_label(selection: CompareSelection) -> str:
         entry = selection.entry
-        return (
+        label = (
             f"{selection.package_name} {entry.version} {entry.build} [{entry.subdir}]"
         )
+        if selection.source is not None:
+            return f"{label} ({selection.source.display_name})"
+        return label
 
-    def _compare_selection_key(self, selection: CompareSelection) -> VersionPreviewKey:
+    def _compare_selection_key(self, selection: CompareSelection) -> ArtifactCacheKey:
+        if selection.source is not None:
+            return selection.source.cache_key
         return self._version_preview_key(selection.package_name, selection.entry)
 
     def _current_compare_selection(self) -> CompareSelection | None:
@@ -952,11 +1058,20 @@ class CondaMetadataTui(App[None]):
         package_name = self._selected_package
         if package_name is None:
             return None
-        return CompareSelection(package_name=package_name, entry=row.entry)
+        preview_key = self._version_preview_key(package_name, row.entry)
+        direct = self._direct_artifacts.get(preview_key)
+        return CompareSelection(
+            package_name=package_name,
+            entry=row.entry,
+            source=None if direct is None else direct.source,
+        )
 
     async def _load_compare_artifact(
         self, selection: CompareSelection
-    ) -> tuple[RepoDataRecord, VersionArtifactData] | None:
+    ) -> tuple[RepoDataRecord | None, VersionArtifactData] | None:
+        if selection.source is not None:
+            loaded = await self._version_loader.load_artifact_source(selection.source)
+            return None, loaded.data
         record = await self._get_record_for_version_entry(
             selection.package_name, selection.entry
         )
@@ -984,6 +1099,18 @@ class CondaMetadataTui(App[None]):
         assert contents is not None
         return sha256(contents).digest()
 
+    async def _archive_for_selection(
+        self, selection: CompareSelection
+    ) -> PackageArchive:
+        if selection.source is not None:
+            return await self._version_loader.get_artifact_archive(selection.source)
+        url = await self._package_url_for_version_entry(
+            selection.package_name, selection.entry
+        )
+        return await self._version_loader.get_package_archive(
+            self._compare_selection_key(selection), url
+        )
+
     async def _resolve_compare_info_file_and_open(
         self, screen: CompareScreen, row: CompareFileRow
     ) -> None:
@@ -994,18 +1121,8 @@ class CondaMetadataTui(App[None]):
         original_left_path = row.left_file.path
         original_right_path = row.right_file.path
         try:
-            left_url = await self._package_url_for_version_entry(
-                original_left.package_name, original_left.entry
-            )
-            right_url = await self._package_url_for_version_entry(
-                original_right.package_name, original_right.entry
-            )
-            left_archive = await self._version_loader.get_package_archive(
-                self._compare_selection_key(original_left), left_url
-            )
-            right_archive = await self._version_loader.get_package_archive(
-                self._compare_selection_key(original_right), right_url
-            )
+            left_archive = await self._archive_for_selection(original_left)
+            right_archive = await self._archive_for_selection(original_right)
             left_sha256 = await self._info_file_sha256(left_archive, original_left_path)
             right_sha256 = await self._info_file_sha256(
                 right_archive, original_right_path
@@ -1095,17 +1212,20 @@ class CondaMetadataTui(App[None]):
         if self._compare_screen_open:
             return
 
-        ordered_pairs = [
+        ordered_pairs: list[
+            tuple[CompareSelection, RepoDataRecord | None, VersionArtifactData]
+        ] = [
             (left_selection, left_record, left_artifact),
             (right_selection, right_record, right_artifact),
         ]
-        ordered_pairs.sort(
-            key=lambda pair: (
-                *self._record_sort_key(pair[1]),
-                pair[1].file_name,
-                pair[1].name.source,
-            ),
-        )
+        if left_record is not None and right_record is not None:
+            ordered_pairs.sort(
+                key=lambda pair: (
+                    *self._record_sort_key(cast(RepoDataRecord, pair[1])),
+                    cast(RepoDataRecord, pair[1]).file_name,
+                    cast(RepoDataRecord, pair[1]).name.source,
+                ),
+            )
         # Deliberately normalize the compare pane order for a stable display,
         # even when the user picked compare A/B in the opposite order.
         (left_selection, _, left_artifact), (right_selection, _, right_artifact) = (
@@ -1193,11 +1313,36 @@ class CondaMetadataTui(App[None]):
 
         temporary_destination: Path | None = None
         try:
-            url = await self._package_url_for_version_entry(package_name, entry)
             destination = (Path.cwd() / entry.file_name).resolve()
+            direct = self._direct_artifacts.get(
+                self._version_preview_key(package_name, entry)
+            )
+            if (
+                direct is not None
+                and isinstance(direct.source, LocalArtifactSource)
+                and direct.source.path == destination
+            ):
+                self.notify(
+                    f"Artifact is already at {destination}",
+                    title="Download",
+                )
+                return
             temporary_destination = destination.with_name(f"{destination.name}.part")
-
-            await package_download_to_path(self._client, url, temporary_destination)
+            if direct is None:
+                url = await self._package_url_for_version_entry(package_name, entry)
+                await package_download_to_path(self._client, url, temporary_destination)
+            elif isinstance(direct.source, LocalArtifactSource):
+                await asyncio.to_thread(
+                    shutil.copyfile,
+                    direct.source.path,
+                    temporary_destination,
+                )
+            else:
+                await package_download_to_path(
+                    self._client,
+                    direct.source.url,
+                    temporary_destination,
+                )
             temporary_destination.replace(destination)
         except Exception as exc:
             if temporary_destination is not None:
@@ -1397,8 +1542,25 @@ class CondaMetadataTui(App[None]):
         self.call_after_refresh(lambda: self._open_compare_file_action_screen(row))
 
     async def _fetch_package_file_bytes(
-        self, package_name: str, entry: VersionEntry, file_path: str
+        self,
+        package_name: str,
+        entry: VersionEntry,
+        file_path: str,
+        *,
+        source: ArtifactSource | None = None,
     ) -> bytes:
+        if source is None:
+            preview_key = self._version_preview_key(package_name, entry)
+            direct = self._direct_artifacts.get(preview_key)
+            if direct is not None:
+                source = direct.source
+        if source is not None:
+            archive = await self._version_loader.get_artifact_archive(source)
+            contents = await archive.read_file(file_path)
+            if contents is None:
+                raise FileNotFoundError(f"Package does not contain {file_path}")
+            return contents
+
         url = await self._package_url_for_version_entry(package_name, entry)
 
         return await fetch_raw_package_file_from_url(self._client, url, file_path)
@@ -1492,6 +1654,7 @@ class CondaMetadataTui(App[None]):
         file_path: str,
         *,
         destination_path: str | None = None,
+        source: ArtifactSource | None = None,
     ) -> None:
         temporary_destination: Path | None = None
         try:
@@ -1502,9 +1665,15 @@ class CondaMetadataTui(App[None]):
             )
             destination.parent.mkdir(parents=True, exist_ok=True)
             temporary_destination = destination.with_name(f"{destination.name}.part")
-            temporary_destination.write_bytes(
-                await self._fetch_package_file_bytes(package_name, entry, file_path)
-            )
+            if source is None:
+                package_bytes = await self._fetch_package_file_bytes(
+                    package_name, entry, file_path
+                )
+            else:
+                package_bytes = await self._fetch_package_file_bytes(
+                    package_name, entry, file_path, source=source
+                )
+            temporary_destination.write_bytes(package_bytes)
             temporary_destination.replace(destination)
         except Exception as exc:
             if temporary_destination is not None:
@@ -1530,6 +1699,7 @@ class CondaMetadataTui(App[None]):
         sha256: bytes | None = None,
         *,
         title_prefix: str | None = None,
+        source: ArtifactSource | None = None,
     ) -> None:
         try:
             preview_title = self._preview_title(file_path, size_in_bytes=size_in_bytes)
@@ -1549,9 +1719,14 @@ class CondaMetadataTui(App[None]):
                     )
                 )
                 return
-            package_bytes = await self._fetch_package_file_bytes(
-                package_name, entry, file_path
-            )
+            if source is None:
+                package_bytes = await self._fetch_package_file_bytes(
+                    package_name, entry, file_path
+                )
+            else:
+                package_bytes = await self._fetch_package_file_bytes(
+                    package_name, entry, file_path, source=source
+                )
             preview_title = self._preview_title(file_path, package_bytes)
             if title_prefix is not None:
                 preview_title = f"{title_prefix}: {preview_title}"
@@ -1655,6 +1830,7 @@ class CondaMetadataTui(App[None]):
                     selection.entry,
                     package_file.path,
                     destination_path=destination_path,
+                    source=selection.source,
                 )
                 return
             if action.action == "preview":
@@ -1665,6 +1841,7 @@ class CondaMetadataTui(App[None]):
                     package_file.size_in_bytes,
                     package_file.sha256,
                     title_prefix=title_prefix,
+                    source=selection.source,
                 )
                 return
         finally:
@@ -1941,6 +2118,9 @@ class CondaMetadataTui(App[None]):
         await self._apply_matchspec_result(query, result)
 
     def _back_to_packages(self) -> None:
+        if self._artifact_sources:
+            self.exit()
+            return
         self._mode = "packages"
         self._draft_selected_platform_names = None
         self._clear_version_state()
@@ -2033,6 +2213,8 @@ class CondaMetadataTui(App[None]):
             )
 
         if self._mode == "versions":
+            if self._artifact_sources:
+                return "Artifact files: Enter | Back: esc | Quit: q | Help: ?"
             footer = Text("Search: / | Platform: p | Channel: c | MatchSpec: m")
             footer.append(" | ")
             compare_start = len(footer)
@@ -2047,7 +2229,9 @@ class CondaMetadataTui(App[None]):
         return "Search: / | Platform: p | Channel: c | MatchSpec: m | Help: ?"
 
     def _sidebar_title_text(self, *, selected: bool) -> Text:
-        if self._mode == "versions":
+        if self._artifact_sources:
+            label = "Artifact"
+        elif self._mode == "versions":
             label = (
                 f"Versions: {self._selected_package}"
                 if self._selected_package is not None

--- a/pixi_browse/tui/state.py
+++ b/pixi_browse/tui/state.py
@@ -7,6 +7,7 @@ from rattler.platform import Platform
 from rattler.repo_data import RepoDataRecord
 
 from pixi_browse.models import (
+    ArtifactCacheKey,
     CompareSelection,
     PackageFile,
     VersionArtifactData,
@@ -52,10 +53,10 @@ class ChannelStateSnapshot:
     matchspec_query: str
     matchspec_records_by_package: dict[str, list[RepoDataRecord]]
     package_records_cache: dict[str, list[RepoDataRecord]]
-    version_archive_cache: dict[VersionPreviewKey, PackageArchive]
-    version_about_urls_cache: dict[VersionPreviewKey, AboutUrls]
-    version_paths_cache: dict[VersionPreviewKey, list[PackageFile]]
-    version_artifact_data_cache: dict[VersionPreviewKey, VersionArtifactData]
+    version_archive_cache: dict[ArtifactCacheKey, PackageArchive]
+    version_about_urls_cache: dict[ArtifactCacheKey, AboutUrls]
+    version_paths_cache: dict[ArtifactCacheKey, list[PackageFile]]
+    version_artifact_data_cache: dict[ArtifactCacheKey, VersionArtifactData]
     compare_selection: CompareSelection | None
     last_package_highlight: int | None
     last_package_scroll_y: float

--- a/pixi_browse/tui/version_loader.py
+++ b/pixi_browse/tui/version_loader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 
 import yaml
 from rattler.networking import Client
@@ -9,23 +9,37 @@ from rattler.package_streaming import PackageArchive
 from rattler.repo_data import RepoDataRecord
 
 from pixi_browse.models import (
+    ArtifactCacheKey,
+    ArtifactMetadata,
+    ArtifactSource,
+    LocalArtifactSource,
     PackageFile,
     PackageFilePathType,
     VersionArtifactData,
+    VersionEntry,
     VersionPreviewKey,
 )
-from pixi_browse.rendering import build_version_artifact_data
+from pixi_browse.rendering import build_artifact_data, build_version_artifact_data
 
 from .state import AboutUrls
+
+
+@dataclass(frozen=True)
+class LoadedArtifact:
+    source: ArtifactSource
+    metadata: ArtifactMetadata
+    entry: VersionEntry
+    archive: PackageArchive
+    data: VersionArtifactData
 
 
 class VersionDataLoader:
     def __init__(self, *, client: Client) -> None:
         self._client = client
-        self.archive_cache: dict[VersionPreviewKey, PackageArchive] = {}
-        self.about_urls_cache: dict[VersionPreviewKey, AboutUrls] = {}
-        self.paths_cache: dict[VersionPreviewKey, list[PackageFile]] = {}
-        self.artifact_data_cache: dict[VersionPreviewKey, VersionArtifactData] = {}
+        self.archive_cache: dict[ArtifactCacheKey, PackageArchive] = {}
+        self.about_urls_cache: dict[ArtifactCacheKey, AboutUrls] = {}
+        self.paths_cache: dict[ArtifactCacheKey, list[PackageFile]] = {}
+        self.artifact_data_cache: dict[ArtifactCacheKey, VersionArtifactData] = {}
 
     def clear_caches(self) -> None:
         self.archive_cache.clear()
@@ -36,10 +50,10 @@ class VersionDataLoader:
     def restore_caches(
         self,
         *,
-        archive_cache: dict[VersionPreviewKey, PackageArchive],
-        about_urls_cache: dict[VersionPreviewKey, AboutUrls],
-        paths_cache: dict[VersionPreviewKey, list[PackageFile]],
-        artifact_data_cache: dict[VersionPreviewKey, VersionArtifactData],
+        archive_cache: dict[ArtifactCacheKey, PackageArchive],
+        about_urls_cache: dict[ArtifactCacheKey, AboutUrls],
+        paths_cache: dict[ArtifactCacheKey, list[PackageFile]],
+        artifact_data_cache: dict[ArtifactCacheKey, VersionArtifactData],
     ) -> None:
         self.archive_cache.clear()
         self.archive_cache.update(archive_cache)
@@ -77,7 +91,7 @@ class VersionDataLoader:
         return str(rattler_build_version)
 
     async def get_package_paths(
-        self, preview_key: VersionPreviewKey, archive: PackageArchive
+        self, preview_key: ArtifactCacheKey, archive: PackageArchive
     ) -> list[PackageFile]:
         cached = self.paths_cache.get(preview_key)
         if cached is not None:
@@ -112,7 +126,7 @@ class VersionDataLoader:
         return paths
 
     async def get_package_archive(
-        self, preview_key: VersionPreviewKey, url: str
+        self, preview_key: ArtifactCacheKey, url: str
     ) -> PackageArchive:
         cached = self.archive_cache.get(preview_key)
         if cached is not None:
@@ -122,8 +136,20 @@ class VersionDataLoader:
         self.archive_cache[preview_key] = archive
         return archive
 
+    async def get_artifact_archive(self, source: ArtifactSource) -> PackageArchive:
+        cached = self.archive_cache.get(source.cache_key)
+        if cached is not None:
+            return cached
+
+        if isinstance(source, LocalArtifactSource):
+            archive = await PackageArchive.from_path(source.path)
+        else:
+            archive = await PackageArchive.from_url(self._client, source.url)
+        self.archive_cache[source.cache_key] = archive
+        return archive
+
     async def get_about_urls(
-        self, preview_key: VersionPreviewKey, archive: PackageArchive
+        self, preview_key: ArtifactCacheKey, archive: PackageArchive
     ) -> AboutUrls:
         cached = self.about_urls_cache.get(preview_key)
         if cached is not None:
@@ -257,3 +283,75 @@ class VersionDataLoader:
         )
         self.artifact_data_cache[preview_key] = artifact_data
         return artifact_data
+
+    async def load_artifact_source(self, source: ArtifactSource) -> LoadedArtifact:
+        archive = await self.get_artifact_archive(source)
+        index = await archive.index_json()
+        if isinstance(source, LocalArtifactSource):
+            file_name = source.path.name
+            size = source.path.stat().st_size
+        else:
+            file_name = source.display_name
+            size = None
+        if not file_name:
+            file_name = f"{index.name.source}-{index.version}-{index.build}.conda"
+
+        metadata = ArtifactMetadata(
+            name=index.name.normalized,
+            version=index.version,
+            build=index.build,
+            build_number=index.build_number,
+            subdir=index.subdir or "unknown",
+            file_name=file_name,
+            source=source,
+            dependencies=tuple(index.depends),
+            constraints=tuple(index.constrains),
+            size=size,
+            timestamp=index.timestamp,
+            license=index.license,
+            license_family=index.license_family,
+            arch=index.arch,
+            platform=index.platform,
+            features=index.features,
+            track_features=tuple(index.track_features),
+        )
+        entry = VersionEntry(
+            version=metadata.version,
+            build=metadata.build,
+            build_number=metadata.build_number,
+            subdir=metadata.subdir,
+            file_name=metadata.file_name,
+        )
+
+        cached = self.artifact_data_cache.get(source.cache_key)
+        if cached is not None:
+            return LoadedArtifact(source, metadata, entry, archive, cached)
+
+        package_paths = await self.get_package_paths(source.cache_key, archive)
+        info_files = await self.get_info_files(archive)
+        about_urls = AboutUrls()
+        run_exports: RunExportsJson | None = None
+        try:
+            about_urls = await self.get_about_urls(source.cache_key, archive)
+        except Exception:
+            pass
+        try:
+            run_exports = await self.get_run_exports(archive)
+        except Exception:
+            pass
+
+        artifact_data = build_artifact_data(
+            metadata,
+            package_paths=package_paths,
+            info_files=info_files,
+            repository_urls=about_urls.repository,
+            documentation_urls=about_urls.documentation,
+            homepage_urls=about_urls.homepage,
+            recipe_maintainers=about_urls.recipe_maintainers,
+            provenance_remote_url=about_urls.provenance_remote_url,
+            provenance_sha=about_urls.provenance_sha,
+            rattler_build_version=about_urls.rattler_build_version,
+            run_exports=run_exports,
+        )
+        self.artifact_data_cache[source.cache_key] = artifact_data
+        return LoadedArtifact(source, metadata, entry, archive, artifact_data)

--- a/pixi_browse/tui/version_loader.py
+++ b/pixi_browse/tui/version_loader.py
@@ -8,9 +8,10 @@ from rattler.package import PathType, RunExportsJson
 from rattler.package_streaming import PackageArchive
 from rattler.repo_data import RepoDataRecord
 
+from pixi_browse.artifacts import into_package_record
 from pixi_browse.models import (
     ArtifactCacheKey,
-    ArtifactMetadata,
+    ArtifactDescriptor,
     ArtifactSource,
     LocalArtifactSource,
     PackageFile,
@@ -27,7 +28,7 @@ from .state import AboutUrls
 @dataclass(frozen=True)
 class LoadedArtifact:
     source: ArtifactSource
-    metadata: ArtifactMetadata
+    descriptor: ArtifactDescriptor
     entry: VersionEntry
     archive: PackageArchive
     data: VersionArtifactData
@@ -296,36 +297,25 @@ class VersionDataLoader:
         if not file_name:
             file_name = f"{index.name.source}-{index.version}-{index.build}.conda"
 
-        metadata = ArtifactMetadata(
-            name=index.name.normalized,
-            version=index.version,
-            build=index.build,
-            build_number=index.build_number,
-            subdir=index.subdir or "unknown",
+        record = into_package_record(index)
+        if size is not None:
+            record.size = size
+        descriptor = ArtifactDescriptor(
+            record=record,
             file_name=file_name,
             source=source,
-            dependencies=tuple(index.depends),
-            constraints=tuple(index.constrains),
-            size=size,
-            timestamp=index.timestamp,
-            license=index.license,
-            license_family=index.license_family,
-            arch=index.arch,
-            platform=index.platform,
-            features=index.features,
-            track_features=tuple(index.track_features),
         )
         entry = VersionEntry(
-            version=metadata.version,
-            build=metadata.build,
-            build_number=metadata.build_number,
-            subdir=metadata.subdir,
-            file_name=metadata.file_name,
+            version=record.version,
+            build=record.build,
+            build_number=record.build_number,
+            subdir=record.subdir,
+            file_name=descriptor.file_name,
         )
 
         cached = self.artifact_data_cache.get(source.cache_key)
         if cached is not None:
-            return LoadedArtifact(source, metadata, entry, archive, cached)
+            return LoadedArtifact(source, descriptor, entry, archive, cached)
 
         package_paths = await self.get_package_paths(source.cache_key, archive)
         info_files = await self.get_info_files(archive)
@@ -341,7 +331,7 @@ class VersionDataLoader:
             pass
 
         artifact_data = build_artifact_data(
-            metadata,
+            descriptor,
             package_paths=package_paths,
             info_files=info_files,
             repository_urls=about_urls.repository,
@@ -354,4 +344,4 @@ class VersionDataLoader:
             run_exports=run_exports,
         )
         self.artifact_data_cache[source.cache_key] = artifact_data
-        return LoadedArtifact(source, metadata, entry, archive, artifact_data)
+        return LoadedArtifact(source, descriptor, entry, archive, artifact_data)

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -1603,9 +1603,12 @@ class CompareScreen(Screen[None]):
     @staticmethod
     def _selection_label(selection: CompareSelection) -> str:
         entry = selection.entry
-        return (
+        label = (
             f"{selection.package_name} {entry.version} {entry.build} [{entry.subdir}]"
         )
+        if selection.source is not None:
+            return f"{label} ({selection.source.display_name})"
+        return label
 
     def action_next_section(self) -> None:
         self.query_one(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 from rattler.match_spec import MatchSpec
 from rattler.platform import Platform
@@ -6,6 +7,7 @@ from typer.testing import CliRunner
 
 import pixi_browse.__main__ as entrypoint
 from pixi_browse import __version__
+from pixi_browse.models import LocalArtifactSource, RemoteArtifactSource
 
 _ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -156,3 +158,69 @@ def test_cli_exits_for_invalid_matchspec(monkeypatch) -> None:
     assert result.exit_code == 1
     assert result.output.strip()
     assert captured == {}
+
+
+def test_inspect_command_passes_local_artifact_source(tmp_path, monkeypatch) -> None:
+    runner = CliRunner()
+    artifact_path = tmp_path / "demo.conda"
+    artifact_path.write_bytes(b"package")
+    captured: dict[str, object] = {}
+
+    class _FakeTui:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run(self) -> None:
+            captured["run_called"] = True
+
+    monkeypatch.setattr(entrypoint, "CondaMetadataTui", _FakeTui)
+
+    result = runner.invoke(entrypoint.cli, ["inspect", str(artifact_path)])
+
+    assert result.exit_code == 0
+    assert captured == {
+        "artifact_sources": [LocalArtifactSource(Path(artifact_path).resolve())],
+        "run_called": True,
+    }
+
+
+def test_compare_command_preserves_remote_artifact_order(monkeypatch) -> None:
+    runner = CliRunner()
+    captured: dict[str, object] = {}
+
+    class _FakeTui:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run(self) -> None:
+            captured["run_called"] = True
+
+    monkeypatch.setattr(entrypoint, "CondaMetadataTui", _FakeTui)
+
+    result = runner.invoke(
+        entrypoint.cli,
+        [
+            "compare",
+            "https://example.com/old.conda",
+            "https://example.com/new.conda?token=secret",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured == {
+        "artifact_sources": [
+            RemoteArtifactSource("https://example.com/old.conda"),
+            RemoteArtifactSource("https://example.com/new.conda?token=secret"),
+        ],
+        "compare_artifacts": True,
+        "run_called": True,
+    }
+
+
+def test_inspect_command_rejects_missing_local_artifact(tmp_path) -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(entrypoint.cli, ["inspect", str(tmp_path / "missing.conda")])
+
+    assert result.exit_code == 2
+    assert "Artifact does not exist" in strip_ansi(result.output)

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -8,7 +8,7 @@ from typing import cast
 import pytest
 from rattler.exceptions import InvalidMatchSpecError
 from rattler.match_spec import MatchSpec
-from rattler.package import NoArchLiteral, RunExportsJson
+from rattler.package import IndexJson, NoArchLiteral, RunExportsJson
 from rattler.package_streaming import PackageArchive
 from rattler.platform import Platform
 from rattler.repo_data import PackageRecord, RepoDataRecord
@@ -23,6 +23,7 @@ from textual.widgets import Static
 
 from pixi_browse import __version__
 from pixi_browse.__main__ import CondaMetadataTui, VersionEntry, VersionRow
+from pixi_browse.artifacts import into_package_record
 from pixi_browse.models import (
     ArtifactCacheKey,
     ArtifactSource,
@@ -513,31 +514,23 @@ def test_load_local_artifact_source_builds_normalized_artifact(
     source = LocalArtifactSource(artifact_path.resolve())
     loader = VersionDataLoader(client=cast(Client, object()))
 
-    @dataclass(frozen=True)
-    class _Name:
-        source: str = "demo"
-        normalized: str = "demo"
-
-    @dataclass(frozen=True)
-    class _Index:
-        name: _Name = _Name()
-        version: Version = Version("1.2.3")
-        build: str = "py313_0"
-        build_number: int = 0
-        subdir: str = "noarch"
-        depends: tuple[str, ...] = ("python >=3.13",)
-        constrains: tuple[str, ...] = ("demo-core >=1",)
-        timestamp: None = None
-        license: str = "BSD-3-Clause"
-        license_family: str = "BSD"
-        arch: None = None
-        platform: None = None
-        features: None = None
-        track_features: tuple[str, ...] = ()
+    index = IndexJson.from_str(
+        """{
+            "name": "demo",
+            "version": "1.2.3",
+            "build": "py313_0",
+            "build_number": 0,
+            "subdir": "noarch",
+            "depends": ["python >=3.13"],
+            "constrains": ["demo-core >=1"],
+            "license": "BSD-3-Clause",
+            "license_family": "BSD"
+        }"""
+    )
 
     class _Archive:
-        async def index_json(self) -> _Index:
-            return _Index()
+        async def index_json(self) -> IndexJson:
+            return index
 
     archive = cast(PackageArchive, _Archive())
 
@@ -578,13 +571,19 @@ def test_load_local_artifact_source_builds_normalized_artifact(
     loaded = asyncio.run(loader.load_artifact_source(source))
 
     assert loaded.source == source
-    assert loaded.metadata.name == "demo"
-    assert loaded.metadata.version == Version("1.2.3")
-    assert loaded.metadata.dependencies == ("python >=3.13",)
+    assert loaded.descriptor.record.name.normalized == "demo"
+    assert loaded.descriptor.record.version == Version("1.2.3")
+    assert loaded.descriptor.record.depends == ["python >=3.13"]
     assert loaded.entry.file_name == artifact_path.name
     assert loaded.data.file_paths == (PackageFile("bin/demo", 42),)
     assert loaded.data.info_files == (PackageFile("info/index.json", 100),)
     assert loaded.data.homepage_urls == ("https://example.com/demo",)
+
+
+def test_into_package_record_keeps_repo_data_record() -> None:
+    record = _make_repo_data_record()
+
+    assert into_package_record(record) is record
 
 
 def test_build_version_compare_data_reports_metadata_dependency_and_file_changes() -> (

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -8,7 +8,7 @@ from typing import cast
 import pytest
 from rattler.exceptions import InvalidMatchSpecError
 from rattler.match_spec import MatchSpec
-from rattler.package import IndexJson, NoArchLiteral, RunExportsJson
+from rattler.package import NoArchLiteral, RunExportsJson
 from rattler.package_streaming import PackageArchive
 from rattler.platform import Platform
 from rattler.repo_data import PackageRecord, RepoDataRecord
@@ -23,14 +23,10 @@ from textual.widgets import Static
 
 from pixi_browse import __version__
 from pixi_browse.__main__ import CondaMetadataTui, VersionEntry, VersionRow
-from pixi_browse.artifacts import into_package_record
 from pixi_browse.models import (
-    ArtifactCacheKey,
-    ArtifactSource,
     CompareFileRow,
     CompareRow,
     CompareSelection,
-    LocalArtifactSource,
     PackageFile,
     VersionArtifactData,
     VersionCompareData,
@@ -504,86 +500,6 @@ def test_load_version_artifact_data_raises_when_package_paths_are_unavailable(
                 preview_key=preview_key,
             )
         )
-
-
-def test_load_local_artifact_source_builds_normalized_artifact(
-    tmp_path, monkeypatch
-) -> None:
-    artifact_path = tmp_path / "demo-1.2.3-py313_0.conda"
-    artifact_path.write_bytes(b"package archive")
-    source = LocalArtifactSource(artifact_path.resolve())
-    loader = VersionDataLoader(client=cast(Client, object()))
-
-    index = IndexJson.from_str(
-        """{
-            "name": "demo",
-            "version": "1.2.3",
-            "build": "py313_0",
-            "build_number": 0,
-            "subdir": "noarch",
-            "depends": ["python >=3.13"],
-            "constrains": ["demo-core >=1"],
-            "license": "BSD-3-Clause",
-            "license_family": "BSD"
-        }"""
-    )
-
-    class _Archive:
-        async def index_json(self) -> IndexJson:
-            return index
-
-    archive = cast(PackageArchive, _Archive())
-
-    async def _fake_get_archive(value: ArtifactSource) -> PackageArchive:
-        assert value == source
-        return archive
-
-    async def _fake_get_paths(
-        key: ArtifactCacheKey, value: PackageArchive
-    ) -> list[PackageFile]:
-        assert key == source.cache_key
-        assert value is archive
-        return [PackageFile("bin/demo", 42)]
-
-    async def _fake_get_info_files(value: PackageArchive) -> list[PackageFile]:
-        assert value is archive
-        return [PackageFile("info/index.json", 100)]
-
-    async def _fake_get_about_urls(
-        key: ArtifactCacheKey, value: PackageArchive
-    ) -> AboutUrls:
-        assert key == source.cache_key
-        assert value is archive
-        return AboutUrls(homepage=("https://example.com/demo",))
-
-    async def _fake_get_run_exports(
-        value: PackageArchive,
-    ) -> RunExportsJson | None:
-        assert value is archive
-        return None
-
-    monkeypatch.setattr(loader, "get_artifact_archive", _fake_get_archive)
-    monkeypatch.setattr(loader, "get_package_paths", _fake_get_paths)
-    monkeypatch.setattr(loader, "get_info_files", _fake_get_info_files)
-    monkeypatch.setattr(loader, "get_about_urls", _fake_get_about_urls)
-    monkeypatch.setattr(loader, "get_run_exports", _fake_get_run_exports)
-
-    loaded = asyncio.run(loader.load_artifact_source(source))
-
-    assert loaded.source == source
-    assert loaded.descriptor.record.name.normalized == "demo"
-    assert loaded.descriptor.record.version == Version("1.2.3")
-    assert loaded.descriptor.record.depends == ["python >=3.13"]
-    assert loaded.entry.file_name == artifact_path.name
-    assert loaded.data.file_paths == (PackageFile("bin/demo", 42),)
-    assert loaded.data.info_files == (PackageFile("info/index.json", 100),)
-    assert loaded.data.homepage_urls == ("https://example.com/demo",)
-
-
-def test_into_package_record_keeps_repo_data_record() -> None:
-    record = _make_repo_data_record()
-
-    assert into_package_record(record) is record
 
 
 def test_build_version_compare_data_reports_metadata_dependency_and_file_changes() -> (

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -24,9 +24,12 @@ from textual.widgets import Static
 from pixi_browse import __version__
 from pixi_browse.__main__ import CondaMetadataTui, VersionEntry, VersionRow
 from pixi_browse.models import (
+    ArtifactCacheKey,
+    ArtifactSource,
     CompareFileRow,
     CompareRow,
     CompareSelection,
+    LocalArtifactSource,
     PackageFile,
     VersionArtifactData,
     VersionCompareData,
@@ -500,6 +503,88 @@ def test_load_version_artifact_data_raises_when_package_paths_are_unavailable(
                 preview_key=preview_key,
             )
         )
+
+
+def test_load_local_artifact_source_builds_normalized_artifact(
+    tmp_path, monkeypatch
+) -> None:
+    artifact_path = tmp_path / "demo-1.2.3-py313_0.conda"
+    artifact_path.write_bytes(b"package archive")
+    source = LocalArtifactSource(artifact_path.resolve())
+    loader = VersionDataLoader(client=cast(Client, object()))
+
+    @dataclass(frozen=True)
+    class _Name:
+        source: str = "demo"
+        normalized: str = "demo"
+
+    @dataclass(frozen=True)
+    class _Index:
+        name: _Name = _Name()
+        version: Version = Version("1.2.3")
+        build: str = "py313_0"
+        build_number: int = 0
+        subdir: str = "noarch"
+        depends: tuple[str, ...] = ("python >=3.13",)
+        constrains: tuple[str, ...] = ("demo-core >=1",)
+        timestamp: None = None
+        license: str = "BSD-3-Clause"
+        license_family: str = "BSD"
+        arch: None = None
+        platform: None = None
+        features: None = None
+        track_features: tuple[str, ...] = ()
+
+    class _Archive:
+        async def index_json(self) -> _Index:
+            return _Index()
+
+    archive = cast(PackageArchive, _Archive())
+
+    async def _fake_get_archive(value: ArtifactSource) -> PackageArchive:
+        assert value == source
+        return archive
+
+    async def _fake_get_paths(
+        key: ArtifactCacheKey, value: PackageArchive
+    ) -> list[PackageFile]:
+        assert key == source.cache_key
+        assert value is archive
+        return [PackageFile("bin/demo", 42)]
+
+    async def _fake_get_info_files(value: PackageArchive) -> list[PackageFile]:
+        assert value is archive
+        return [PackageFile("info/index.json", 100)]
+
+    async def _fake_get_about_urls(
+        key: ArtifactCacheKey, value: PackageArchive
+    ) -> AboutUrls:
+        assert key == source.cache_key
+        assert value is archive
+        return AboutUrls(homepage=("https://example.com/demo",))
+
+    async def _fake_get_run_exports(
+        value: PackageArchive,
+    ) -> RunExportsJson | None:
+        assert value is archive
+        return None
+
+    monkeypatch.setattr(loader, "get_artifact_archive", _fake_get_archive)
+    monkeypatch.setattr(loader, "get_package_paths", _fake_get_paths)
+    monkeypatch.setattr(loader, "get_info_files", _fake_get_info_files)
+    monkeypatch.setattr(loader, "get_about_urls", _fake_get_about_urls)
+    monkeypatch.setattr(loader, "get_run_exports", _fake_get_run_exports)
+
+    loaded = asyncio.run(loader.load_artifact_source(source))
+
+    assert loaded.source == source
+    assert loaded.metadata.name == "demo"
+    assert loaded.metadata.version == Version("1.2.3")
+    assert loaded.metadata.dependencies == ("python >=3.13",)
+    assert loaded.entry.file_name == artifact_path.name
+    assert loaded.data.file_paths == (PackageFile("bin/demo", 42),)
+    assert loaded.data.info_files == (PackageFile("info/index.json", 100),)
+    assert loaded.data.homepage_urls == ("https://example.com/demo",)
 
 
 def test_build_version_compare_data_reports_metadata_dependency_and_file_changes() -> (

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1731,17 +1731,37 @@ def test_action_matchspec_key_m_pushes_matchspec_screen(monkeypatch) -> None:
     assert callback == app._handle_matchspec_result
 
 
-def test_inspect_mode_disables_matchspec_shortcut(monkeypatch) -> None:
+def test_inspect_mode_disables_channel_compare_and_matchspec_shortcuts(
+    monkeypatch,
+) -> None:
     app = CondaMetadataTui(
         artifact_sources=[RemoteArtifactSource("https://example.com/demo.conda")]
     )
     pushed: list[object] = []
+    channel_edits: list[bool] = []
+    compare_selections: list[bool] = []
 
     monkeypatch.setattr(app, "push_screen", lambda *args: pushed.append(args))
+    monkeypatch.setattr(
+        app,
+        "_set_channel_edit_mode",
+        lambda *args, **kwargs: channel_edits.append(True),
+    )
+    monkeypatch.setattr(
+        app,
+        "_current_compare_selection",
+        lambda: compare_selections.append(True),
+    )
 
+    app.action_channel_key_c()
+    app.action_compare_key_c()
     app.action_matchspec_key_m()
 
     assert pushed == []
+    assert channel_edits == []
+    assert compare_selections == []
+    assert "Edit channel" not in app._help_text()
+    assert "Compare selected artifact" not in app._help_text()
     assert "Query MatchSpec" not in app._help_text()
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -28,6 +28,7 @@ from pixi_browse.models import (
     CompareRow,
     CompareSelection,
     PackageFile,
+    RemoteArtifactSource,
     VersionArtifactData,
     VersionCompareData,
 )
@@ -1730,6 +1731,20 @@ def test_action_matchspec_key_m_pushes_matchspec_screen(monkeypatch) -> None:
     assert callback == app._handle_matchspec_result
 
 
+def test_inspect_mode_disables_matchspec_shortcut(monkeypatch) -> None:
+    app = CondaMetadataTui(
+        artifact_sources=[RemoteArtifactSource("https://example.com/demo.conda")]
+    )
+    pushed: list[object] = []
+
+    monkeypatch.setattr(app, "push_screen", lambda *args: pushed.append(args))
+
+    app.action_matchspec_key_m()
+
+    assert pushed == []
+    assert "Query MatchSpec" not in app._help_text()
+
+
 def test_handle_matchspec_result_queues_matchspec_worker(monkeypatch) -> None:
     app = CondaMetadataTui()
     worker_calls: list[dict[str, object]] = []
@@ -1977,6 +1992,31 @@ def test_selecting_dependency_option_opens_matchspec_screen(monkeypatch) -> None
     assert sections == [1]
     assert focused == ["main"]
     assert opened == ["python >=3.12"]
+
+
+def test_inspect_mode_disables_dependency_matchspec_activation(monkeypatch) -> None:
+    app = CondaMetadataTui(
+        artifact_sources=[RemoteArtifactSource("https://example.com/demo.conda")]
+    )
+    app._mode = "versions"
+    opened: list[str] = []
+
+    monkeypatch.setattr(
+        app, "_defer_matchspec_screen", lambda value: opened.append(value)
+    )
+
+    class _FakeOptionList:
+        id = "detail-option-list-1"
+
+    class _FakeEvent:
+        option_list = _FakeOptionList()
+        option_index = 0
+
+    asyncio.run(
+        app.on_option_list_option_selected(_FakeEvent())  # type: ignore[arg-type]
+    )
+
+    assert opened == []
 
 
 def test_on_key_numeric_shortcut_focuses_main_section(monkeypatch) -> None:


### PR DESCRIPTION
closes #13

## Summary

- add `pixi-browse inspect SOURCE` for local paths and HTTP(S) package artifact URLs
- add `pixi-browse compare LEFT RIGHT` for direct side-by-side artifact comparisons
- support both `.conda` and `.tar.bz2` archives through typed local and remote artifact sources
- normalize standalone archive metadata into the existing details and comparison views
- make package file preview, download, and lazy info-file hashing work for direct sources
- preserve explicit left/right ordering for command-line comparisons
- document the new commands and add CLI and loader coverage

## Why

Users can currently inspect packages only after locating them through channel repodata. This makes locally built packages and direct artifact URLs cumbersome to investigate, and comparing two build outputs requires navigating them through the channel-oriented workflow.

These commands make standalone build artifacts first-class inputs while reusing the existing metadata, file, and comparison UI.

## User impact

Users can now inspect and compare any combination of local and remote conda package artifacts directly:

```console
pixi-browse inspect ./package.conda
pixi-browse inspect https://example.com/package.tar.bz2
pixi-browse compare ./released.conda ./locally-built.conda
```

Bare `pixi-browse` and its existing channel options remain unchanged.

## Validation

- `pixi run pytest -q` — 180 passed
- `pixi run lint`
- headless TUI smoke test for direct inspect and compare startup
- loader smoke test with real local `.conda` and `.tar.bz2` artifacts