### PR TITLE
Support comparing noarch, flags, and extra_depends in repodata patches

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -283,7 +283,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarl-1.24.5-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda_source: pixi-browse[d7a8cea7] @ .
-      - conda_source: py-rattler[cb83fc23] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -488,7 +488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zizmor-1.28.0-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - conda_source: pixi-browse[8da38928] @ .
-      - conda_source: py-rattler[a20e3c32] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -693,7 +693,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zizmor-1.28.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: pixi-browse[0da8684d] @ .
-      - conda_source: py-rattler[f114057e] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -875,7 +875,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: pixi-browse[87c1e253] @ .
-      - conda_source: py-rattler[eea55104] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
   py313:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1085,7 +1085,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
       - conda_source: pixi-browse[d7a8cea7] @ .
-      - conda_source: py-rattler[cb83fc23] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -1242,7 +1242,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.24.5-py313h035b7d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - conda_source: pixi-browse[8da38928] @ .
-      - conda_source: py-rattler[a20e3c32] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -1399,7 +1399,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.24.5-py313h65a2061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: pixi-browse[0da8684d] @ .
-      - conda_source: py-rattler[f114057e] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -1534,7 +1534,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: pixi-browse[87c1e253] @ .
-      - conda_source: py-rattler[eea55104] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
   py314:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1746,7 +1746,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarl-1.24.5-pyh7db6752_0.conda
       - conda_source: pixi-browse[d7a8cea7] @ .
-      - conda_source: py-rattler[cb83fc23] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -1905,7 +1905,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - conda_source: pixi-browse[8da38928] @ .
-      - conda_source: py-rattler[a20e3c32] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -2064,7 +2064,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: pixi-browse[0da8684d] @ .
-      - conda_source: py-rattler[f114057e] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -2201,7 +2201,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: pixi-browse[87c1e253] @ .
-      - conda_source: py-rattler[eea55104] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+      - conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   build_number: 20
@@ -6961,28 +6961,28 @@ packages:
   run_exports: {}
   size: 23531
   timestamp: 1787725221261
-- conda: https://conda.anaconda.org/conda-forge/osx-64/clang-23-23.1.0-default_h4b7e6e3_0.conda
-  sha256: 87bbb1dbd819ac80ba6348ff36da1d0b650ff19ee7bcd385657566c6b1cc0363
-  md5: d9865eb5abd62812ffc44df165ad84c4
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang-23-23.1.0-default_h74d5376_1.conda
+  sha256: 2bb0f36af9429558643bc899c3cd3694f288247c12ba2e428b0ae83349787048
+  md5: 281fc335ef3c526960e643abec9e29e6
   depends:
   - compiler-rt23 ==23.1.0
-  - libclang-cpp23.1 ==23.1.0 default_h6e863b9_0
+  - libclang-cpp23.1 ==23.1.0 default_h6e863b9_1
   - libcxx >=23.1.0
   - __osx >=11.0
-  - libzlib >=1.3.2,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   - libxml2
   - libxml2-16 >=2.15.3
+  - libzlib >=1.3.2,<2.0a0
   - libclang-cpp23.1 >=23.1.0,<23.2.0a0
   - libllvm23 >=23.1.0,<23.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   run_exports: {}
-  size: 956629
-  timestamp: 1787735189766
-- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-23.1.0-default_h6e863b9_0.conda
-  sha256: f837061abccaeb1a3bffc74e84940b04f52d37062631ee12621820e99e722168
-  md5: 5c51707247f872bcb01c271107fa77ff
+  size: 956760
+  timestamp: 1788037748188
+- conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-23.1.0-default_h6e863b9_1.conda
+  sha256: cc0904c10f8407228a3a6d9c0b78397f5284e68a017bc5ca4a6057131681b328
+  md5: fff591c63395020c6ebb285554588842
   depends:
   - clang-23 ==23.1.0 default_*
   - compiler-rt_osx-64 ==23.1.0
@@ -6990,15 +6990,15 @@ packages:
   - cctools_impl_osx-64
   - ld64_osx-64 * llvm23_1_*
   - __osx >=11.0
-  - libzlib >=1.3.2,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   - libxml2
   - libxml2-16 >=2.15.3
+  - libzlib >=1.3.2,<2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   run_exports: {}
-  size: 31701
-  timestamp: 1787735189766
+  size: 31833
+  timestamp: 1788037748188
 - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-23.1.0-h4c94ee8_34.conda
   sha256: b5c8a2085b6866def59d932a4a9c5dfa28a04f0f0ca9918d41ada349bbb8fce9
   md5: c3ab7d31724f37e7ed8dc7f61fca9d19
@@ -7445,24 +7445,24 @@ packages:
     - libbrotlienc >=1.2.0,<1.3.0a0
   size: 310355
   timestamp: 1764017609985
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp23.1-23.1.0-default_h6e863b9_0.conda
-  sha256: 1ef8269744c921c85e22512da2fc82c89e76d91459ae67a59a7646103e649f26
-  md5: 1820a7541a8cac2650ba3217c6bfb782
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp23.1-23.1.0-default_h6e863b9_1.conda
+  sha256: 03b2783996d6977e3c69c0338f1c45d1e4084c8046087b7258728de8bf279e88
+  md5: ebd846b462b7db53c9eda061fc7a92a8
   depends:
   - libcxx >=23.1.0
   - __osx >=11.0
-  - libzlib >=1.3.2,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
   - libxml2
   - libxml2-16 >=2.15.3
+  - libzlib >=1.3.2,<2.0a0
   - libllvm23 >=23.1.0,<23.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   run_exports:
     weak:
     - libclang-cpp23.1 >=23.1.0,<23.2.0a0
-  size: 17899779
-  timestamp: 1787735189766
+  size: 17899906
+  timestamp: 1788037748188
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libcompiler-rt-23.1.0-h8c1e6b9_0.conda
   sha256: aee2acc2a2e6ed6792f018ada0c630ac24618cf4b403ebae5ecac4da75c6d7c8
   md5: 6652a0bf4dce86a08ef0d4a1070d78cf
@@ -9378,12 +9378,12 @@ packages:
   run_exports: {}
   size: 23472
   timestamp: 1787724418059
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-23-23.1.0-default_h42eb49c_0.conda
-  sha256: 5f3b1cc03c4efa9fa600a9f48b70ec4bd3fe3385b1fae8f52451aaeccd4e94ef
-  md5: 64e4bb3e2b0adf1bd212ca7498858ae4
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-23-23.1.0-default_h8d85846_1.conda
+  sha256: 4e04848412cec174134108e6eb83b09e5d818e40e14b633c907ce33880fa5e5e
+  md5: 1650da90472c7a9233ba16db61353dbc
   depends:
   - compiler-rt23 ==23.1.0
-  - libclang-cpp23.1 ==23.1.0 default_h79071a4_0
+  - libclang-cpp23.1 ==23.1.0 default_h79071a4_1
   - libcxx >=23.1.0
   - __osx >=11.0
   - libxml2
@@ -9395,11 +9395,11 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   run_exports: {}
-  size: 955039
-  timestamp: 1787735061055
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-23.1.0-default_h79071a4_0.conda
-  sha256: 6cb205181b4dfaf09f04bc8115e1096553a79d723cdbb586f92260eca5414177
-  md5: 4baa3b1105a6e8e4b376c20ef4e0783c
+  size: 955202
+  timestamp: 1788037688863
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-23.1.0-default_h79071a4_1.conda
+  sha256: 4f68f737a5bc8dc0a16a3ef93d65fda90bb3fd7b7a4a794218953f3be6d64ab2
+  md5: 3027f04a9c391ddc416b96e021c9c230
   depends:
   - clang-23 ==23.1.0 default_*
   - compiler-rt_osx-arm64 ==23.1.0
@@ -9414,8 +9414,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   run_exports: {}
-  size: 31752
-  timestamp: 1787735061055
+  size: 31880
+  timestamp: 1788037688863
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-23.1.0-hafa0770_34.conda
   sha256: 3485da2f249bc4eee4d84567f864ec2fb54d5b35812f7504c0b80ee3da740565
   md5: 6080cdced45d99f30a080bda6cec5f2a
@@ -9875,9 +9875,9 @@ packages:
     - libbrotlienc >=1.2.0,<1.3.0a0
   size: 290754
   timestamp: 1764018009077
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp23.1-23.1.0-default_h79071a4_0.conda
-  sha256: d483229aa03fcad6db6714836e114d205e686d79d234cbecd711c26bb6a34a6c
-  md5: 7d658d361008c757fc7dc4c2a64a0e99
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp23.1-23.1.0-default_h79071a4_1.conda
+  sha256: 6d099276edaca530daddb513e8b8ec26162717f2811730f916cf9cd54c265ffb
+  md5: 9f779b62a9a86982e7a8e9fb504ed967
   depends:
   - libcxx >=23.1.0
   - __osx >=11.0
@@ -9891,8 +9891,8 @@ packages:
   run_exports:
     weak:
     - libclang-cpp23.1 >=23.1.0,<23.2.0a0
-  size: 16608844
-  timestamp: 1787735061055
+  size: 16608953
+  timestamp: 1788037688863
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcompiler-rt-23.1.0-hdb3d66b_0.conda
   sha256: edce699ad7485a61911d6ed26b325dd4b0b662f004e35140c4c075f3e7e6e633
   md5: eacac12850a7aa2122a11109a1338b93
@@ -13734,14 +13734,14 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-- conda_source: py-rattler[a20e3c32] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+- conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
   version: 0.25.0
-  build: h4778241_0
-  subdir: osx-64
+  build: hea27dcd_0
+  subdir: osx-arm64
   variants:
     c_stdlib: macosx_deployment_target
     c_stdlib_version: '13.0'
-    target_platform: osx-64
+    target_platform: osx-arm64
   depends:
   - python >=3.10
   - __osx >=13.0
@@ -13752,38 +13752,38 @@ packages:
   license: BSD-3-Clause
   build_packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt23_osx-64-23.1.0-h8d5f570_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-23.1.0-h694c41f_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-64-13.0-h2830193_7.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.97.1-h38e4360_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_impl_osx-64-1030.6.3-llvm23_1_h3bd330e_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1030.6.3-llvm23_1_h254e556_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-23-23.1.0-default_h4b7e6e3_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-23.1.0-default_h6e863b9_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-23.1.0-h4c94ee8_34.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-23.1.0-h694c41f_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt23-23.1.0-h8c1e6b9_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-956.6-llvm23_1_h484b24f_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp23.1-23.1.0-default_h6e863b9_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcompiler-rt-23.1.0-h8c1e6b9_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm23-23.1.0-hd11396f_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libsigtool-0.1.3-h8c25ef7_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h0d7f165_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h0712280_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-23-23.1.0-h36529c3_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-23.1.0-h8c1e6b9_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.97.1-h5655b98_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/rust_osx-64-1.97.1-hb98ad99_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-h8c25ef7_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h44950e2_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt23_osx-arm64-23.1.0-hb8825d9_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-23.1.0-hce30654_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-arm64-13.0-h95484f9_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.97.1-hf6ec828_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_impl_osx-arm64-1030.6.3-llvm23_1_hf5e010b_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1030.6.3-llvm23_1_h54b4f4b_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-23-23.1.0-default_h8d85846_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-23.1.0-default_h79071a4_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-23.1.0-hafa0770_34.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-23.1.0-hce30654_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt23-23.1.0-hdb3d66b_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm23_1_hc8058f9_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp23.1-23.1.0-default_h79071a4_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcompiler-rt-23.1.0-hdb3d66b_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm23-23.1.0-h759d1ac_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h6967ea9_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-heed7d32_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-23-23.1.0-h79441dc_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-23.1.0-hdb3d66b_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.97.1-h4ff7c5d_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust_osx-arm64-1.97.1-h3e48229_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-hb561403_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
   host_packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
@@ -13793,21 +13793,22 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.15.0-py310h9447aaa_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.21-hea035f4_0_cpython.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.12.7-h6c1caad_0.conda
-- conda_source: py-rattler[cb83fc23] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.15.0-py310h76e2da2_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.21-hac0b6dc_0_cpython.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.7-h0e72303_0.conda
+- conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
   version: 0.25.0
   build: ha35fb5c_0
   subdir: linux-64
@@ -13877,7 +13878,80 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-- conda_source: py-rattler[eea55104] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
+- conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+  version: 0.25.0
+  build: h4778241_0
+  subdir: osx-64
+  variants:
+    c_stdlib: macosx_deployment_target
+    c_stdlib_version: '13.0'
+    target_platform: osx-64
+  depends:
+  - python >=3.10
+  - __osx >=13.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __osx >=11.0
+  license: BSD-3-Clause
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt23_osx-64-23.1.0-h8d5f570_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-23.1.0-h694c41f_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-64-13.0-h2830193_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.97.1-h38e4360_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_impl_osx-64-1030.6.3-llvm23_1_h3bd330e_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-1030.6.3-llvm23_1_h254e556_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-23-23.1.0-default_h74d5376_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-23.1.0-default_h6e863b9_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-23.1.0-h4c94ee8_34.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-23.1.0-h694c41f_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt23-23.1.0-h8c1e6b9_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-956.6-llvm23_1_h484b24f_6.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp23.1-23.1.0-default_h6e863b9_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcompiler-rt-23.1.0-h8c1e6b9_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm23-23.1.0-hd11396f_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libsigtool-0.1.3-h8c25ef7_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h0d7f165_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h0712280_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-23-23.1.0-h36529c3_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-23.1.0-h8c1e6b9_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.97.1-h5655b98_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/rust_osx-64-1.97.1-hb98ad99_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-codesign-0.1.3-h8c25ef7_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1600.0.11.8-h44950e2_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.10.21-py310hd8ed1ab_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python-abi3-3.10-h437e749_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.21-hd8ed1ab_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.15.0-py310h9447aaa_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.21-hea035f4_0_cpython.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.12.7-h6c1caad_0.conda
+- conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
   version: 0.25.0
   build: he01afda_0
   subdir: win-64
@@ -13923,77 +13997,3 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
   - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
   - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
-- conda_source: py-rattler[f114057e] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#4e8a067ddc99937d2e8790247abf0af78b6740d0
-  version: 0.25.0
-  build: hea27dcd_0
-  subdir: osx-arm64
-  variants:
-    c_stdlib: macosx_deployment_target
-    c_stdlib_version: '13.0'
-    target_platform: osx-arm64
-  depends:
-  - python >=3.10
-  - __osx >=13.0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  constrains:
-  - __osx >=11.0
-  license: BSD-3-Clause
-  build_packages:
-  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt23_osx-arm64-23.1.0-hb8825d9_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-23.1.0-hce30654_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/macosx_deployment_target_osx-arm64-13.0-h95484f9_7.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.97.1-hf6ec828_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_impl_osx-arm64-1030.6.3-llvm23_1_hf5e010b_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-1030.6.3-llvm23_1_h54b4f4b_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-23-23.1.0-default_h42eb49c_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-23.1.0-default_h79071a4_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-23.1.0-hafa0770_34.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-23.1.0-hce30654_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt23-23.1.0-hdb3d66b_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm23_1_hc8058f9_6.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp23.1-23.1.0-default_h79071a4_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcompiler-rt-23.1.0-hdb3d66b_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm23-23.1.0-h759d1ac_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h6967ea9_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-heed7d32_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-23-23.1.0-h79441dc_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-23.1.0-hdb3d66b_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.97.1-h4ff7c5d_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust_osx-arm64-1.97.1-h3e48229_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1600.0.11.8-hb561403_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  host_packages:
-  - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.10.21-py310hd8ed1ab_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python-abi3-3.10-h437e749_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.21-hd8ed1ab_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.15.0-py310h76e2da2_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.21-hac0b6dc_0_cpython.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.7-h0e72303_0.conda

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -476,7 +476,7 @@ def build_repodata_patch_diff(
     https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/98e5f9bcb6a31f56d168a7e343c7ad70c784e194/recipe/gen_patch_json.py#L600-L603
 
     ``purls`` and ``repodata_revision`` are available on ``IndexJson`` but not on
-    py-rattler's ``PackageRecord``, so they cannot be compared yet.
+    py-rattler's ``PackageRecord``, so they cannot be compared.
     """
     scalar_fields: tuple[tuple[str, object, object], ...] = (
         ("version", index_json.version, record.version),

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 
 from rattler.exceptions import InvalidMatchSpecError
 from rattler.match_spec import MatchSpec
-from rattler.package import IndexJson, RunExportsJson
+from rattler.package import IndexJson, NoArchType, RunExportsJson
 from rattler.repo_data import RepoDataRecord
 from rich.markup import escape
 
@@ -443,6 +443,12 @@ def _repodata_field_text(value: object) -> str:
     """Render an ``index.json``/repodata field for a plain-text diff cell."""
     if value is None:
         return ""
+    if isinstance(value, NoArchType):
+        if value.python:
+            return "python"
+        if value.generic:
+            return "generic"
+        return ""
     if isinstance(value, (list, tuple)):
         return ", ".join(str(item) for item in value)
     if isinstance(value, datetime):
@@ -468,6 +474,9 @@ def build_repodata_patch_diff(
     fill it in for every record that lacks it, which is every rattler-build
     package, so it would flag nearly all recent artifacts as patched. See
     https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/blob/98e5f9bcb6a31f56d168a7e343c7ad70c784e194/recipe/gen_patch_json.py#L600-L603
+
+    ``purls`` and ``repodata_revision`` are available on ``IndexJson`` but not on
+    py-rattler's ``PackageRecord``, so they cannot be compared yet.
     """
     scalar_fields: tuple[tuple[str, object, object], ...] = (
         ("version", index_json.version, record.version),
@@ -477,8 +486,13 @@ def build_repodata_patch_diff(
         ("features", index_json.features, record.features),
         ("track_features", index_json.track_features, record.track_features),
         ("timestamp", index_json.timestamp, record.timestamp),
-        # TODO: compare `noarch` once py-rattler exposes it on `IndexJson`,
-        # see https://github.com/pavelzw/pixi-browse/issues/93
+        ("noarch", index_json.noarch, record.noarch),
+        (
+            "python_site_packages_path",
+            index_json.python_site_packages_path,
+            record.python_site_packages_path,
+        ),
+        ("flags", index_json.flags, record.flags),
     )
     metadata_rows: list[CompareRow] = []
     for label, unpatched, patched in scalar_fields:
@@ -499,13 +513,32 @@ def build_repodata_patch_diff(
             )
         )
 
-    dependencies = tuple(
+    dependency_rows: list[CompareRow] = [
         CompareRow(label="depends", left=row.left, right=row.right, changed=True)
         for row in _diff_dependency_group(
             index_json.depends, record.depends, run_export=False
         )
         if row.changed
-    )
+    ]
+    # Extra dependency groups (`pkg[extras=["group"]]`) are patched per group.
+    unpatched_extra_depends = index_json.extra_depends
+    patched_extra_depends = record.extra_depends
+    for group in sorted({*unpatched_extra_depends, *patched_extra_depends}):
+        dependency_rows.extend(
+            CompareRow(
+                label=f"extra_depends[{group}]",
+                left=row.left,
+                right=row.right,
+                changed=True,
+            )
+            for row in _diff_dependency_group(
+                unpatched_extra_depends.get(group, []),
+                patched_extra_depends.get(group, []),
+                run_export=False,
+            )
+            if row.changed
+        )
+    dependencies = tuple(dependency_rows)
     constraints = tuple(
         CompareRow(label="constrains", left=row.left, right=row.right, changed=True)
         for row in _diff_dependency_group(

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -4,7 +4,7 @@ import shutil
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import cast
+from typing import Literal, cast
 
 import pytest
 from rattler.exceptions import InvalidMatchSpecError, InvalidPackageNameError
@@ -183,6 +183,8 @@ def _make_repo_data_record(
     legacy_bz2_size: int | None = None,
     depends: list[str] | None = None,
     constrains: list[str] | None = None,
+    extra_depends: dict[str, list[str]] | None = None,
+    flags: list[str] | None = None,
     url: str | None = None,
 ) -> RepoDataRecord:
     resolved_file_name = file_name or f"{name}-{version}-{build}.conda"
@@ -198,6 +200,8 @@ def _make_repo_data_record(
             noarch=noarch,
             depends=depends,
             constrains=constrains,
+            extra_depends=extra_depends,
+            flags=flags,
             sha256=sha256,
             md5=md5,
             size=size,
@@ -369,6 +373,10 @@ def _make_index_json(
     license_family: str | None = None,
     track_features: list[str] | None = None,
     subdir: str | None = "keep",
+    noarch: NoArchLiteral | Literal["keep"] = "keep",
+    python_site_packages_path: str | None | Literal["keep"] = "keep",
+    flags: list[str] | None = None,
+    extra_depends: dict[str, list[str]] | None = None,
 ) -> IndexJson:
     """Build an ``info/index.json`` that matches ``record`` unless overridden."""
     data: dict[str, object] = {
@@ -378,6 +386,10 @@ def _make_index_json(
         "build_number": record.build_number,
         "depends": record.depends if depends is None else depends,
         "constrains": record.constrains if constrains is None else constrains,
+        "extra_depends": (
+            record.extra_depends if extra_depends is None else extra_depends
+        ),
+        "flags": record.flags if flags is None else flags,
         "license": record.license if license is None else license,
         "track_features": (
             record.track_features if track_features is None else track_features
@@ -385,6 +397,20 @@ def _make_index_json(
         "arch": record.arch,
         "platform": record.platform,
     }
+    if noarch == "keep":
+        if record.noarch.python:
+            data["noarch"] = "python"
+        elif record.noarch.generic:
+            data["noarch"] = "generic"
+    elif noarch is not None:
+        data["noarch"] = noarch
+    resolved_site_packages_path = (
+        record.python_site_packages_path
+        if python_site_packages_path == "keep"
+        else python_site_packages_path
+    )
+    if resolved_site_packages_path is not None:
+        data["python_site_packages_path"] = resolved_site_packages_path
     resolved_license_family = (
         record.license_family if license_family is None else license_family
     )
@@ -496,6 +522,95 @@ def test_build_repodata_patch_diff_ignores_missing_subdir_in_index_json() -> Non
         record, _make_index_json(record, subdir="noarch")
     ).metadata == (
         CompareRow(label="subdir", left="noarch", right="linux-64", changed=True),
+    )
+
+
+def test_build_repodata_patch_diff_reports_patched_noarch() -> None:
+    """Regression test for https://github.com/pavelzw/pixi-browse/issues/93."""
+    record = _make_repo_data_record(subdir="noarch", noarch="python")
+
+    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
+        RepodataPatchDiff()
+    )
+    assert build_repodata_patch_diff(
+        record, _make_index_json(record, noarch=None)
+    ).metadata == (CompareRow(label="noarch", left="", right="python", changed=True),)
+    assert build_repodata_patch_diff(
+        record, _make_index_json(record, noarch="generic")
+    ).metadata == (
+        CompareRow(label="noarch", left="generic", right="python", changed=True),
+    )
+
+
+def test_build_repodata_patch_diff_reports_patched_python_site_packages_path() -> None:
+    record = _make_repo_data_record(
+        name="python",
+        python_site_packages_path="lib/python3.13t/site-packages",
+    )
+
+    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
+        RepodataPatchDiff()
+    )
+    assert build_repodata_patch_diff(
+        record, _make_index_json(record, python_site_packages_path=None)
+    ).metadata == (
+        CompareRow(
+            label="python_site_packages_path",
+            left="",
+            right="lib/python3.13t/site-packages",
+            changed=True,
+        ),
+    )
+
+
+def test_build_repodata_patch_diff_reports_patched_flags() -> None:
+    record = _make_repo_data_record(flags=["optional"])
+
+    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
+        RepodataPatchDiff()
+    )
+    assert build_repodata_patch_diff(
+        record, _make_index_json(record, flags=[])
+    ).metadata == (CompareRow(label="flags", left="", right="optional", changed=True),)
+
+
+def test_build_repodata_patch_diff_reports_patched_extra_depends() -> None:
+    record = _make_repo_data_record(
+        extra_depends={
+            "scientific": ["numpy >=1.26,<2", "scipy"],
+            "security": ["cryptography >=42"],
+        },
+    )
+
+    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
+        RepodataPatchDiff()
+    )
+    diff = build_repodata_patch_diff(
+        record,
+        _make_index_json(
+            record,
+            extra_depends={"scientific": ["numpy >=1.26"], "docs": ["sphinx"]},
+        ),
+    )
+
+    assert diff.metadata == ()
+    assert diff.dependencies == (
+        CompareRow(label="extra_depends[docs]", left="sphinx", right="", changed=True),
+        CompareRow(
+            label="extra_depends[scientific]",
+            left="numpy >=1.26",
+            right="numpy >=1.26,<2",
+            changed=True,
+        ),
+        CompareRow(
+            label="extra_depends[scientific]", left="", right="scipy", changed=True
+        ),
+        CompareRow(
+            label="extra_depends[security]",
+            left="",
+            right="cryptography >=42",
+            changed=True,
+        ),
     )
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -4,7 +4,7 @@ import shutil
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Literal, cast
+from typing import cast
 
 import pytest
 from rattler.exceptions import InvalidMatchSpecError, InvalidPackageNameError
@@ -183,8 +183,6 @@ def _make_repo_data_record(
     legacy_bz2_size: int | None = None,
     depends: list[str] | None = None,
     constrains: list[str] | None = None,
-    extra_depends: dict[str, list[str]] | None = None,
-    flags: list[str] | None = None,
     url: str | None = None,
 ) -> RepoDataRecord:
     resolved_file_name = file_name or f"{name}-{version}-{build}.conda"
@@ -200,8 +198,6 @@ def _make_repo_data_record(
             noarch=noarch,
             depends=depends,
             constrains=constrains,
-            extra_depends=extra_depends,
-            flags=flags,
             sha256=sha256,
             md5=md5,
             size=size,
@@ -373,10 +369,6 @@ def _make_index_json(
     license_family: str | None = None,
     track_features: list[str] | None = None,
     subdir: str | None = "keep",
-    noarch: NoArchLiteral | Literal["keep"] = "keep",
-    python_site_packages_path: str | None | Literal["keep"] = "keep",
-    flags: list[str] | None = None,
-    extra_depends: dict[str, list[str]] | None = None,
 ) -> IndexJson:
     """Build an ``info/index.json`` that matches ``record`` unless overridden."""
     data: dict[str, object] = {
@@ -386,10 +378,6 @@ def _make_index_json(
         "build_number": record.build_number,
         "depends": record.depends if depends is None else depends,
         "constrains": record.constrains if constrains is None else constrains,
-        "extra_depends": (
-            record.extra_depends if extra_depends is None else extra_depends
-        ),
-        "flags": record.flags if flags is None else flags,
         "license": record.license if license is None else license,
         "track_features": (
             record.track_features if track_features is None else track_features
@@ -397,20 +385,6 @@ def _make_index_json(
         "arch": record.arch,
         "platform": record.platform,
     }
-    if noarch == "keep":
-        if record.noarch.python:
-            data["noarch"] = "python"
-        elif record.noarch.generic:
-            data["noarch"] = "generic"
-    elif noarch is not None:
-        data["noarch"] = noarch
-    resolved_site_packages_path = (
-        record.python_site_packages_path
-        if python_site_packages_path == "keep"
-        else python_site_packages_path
-    )
-    if resolved_site_packages_path is not None:
-        data["python_site_packages_path"] = resolved_site_packages_path
     resolved_license_family = (
         record.license_family if license_family is None else license_family
     )
@@ -522,95 +496,6 @@ def test_build_repodata_patch_diff_ignores_missing_subdir_in_index_json() -> Non
         record, _make_index_json(record, subdir="noarch")
     ).metadata == (
         CompareRow(label="subdir", left="noarch", right="linux-64", changed=True),
-    )
-
-
-def test_build_repodata_patch_diff_reports_patched_noarch() -> None:
-    """Regression test for https://github.com/pavelzw/pixi-browse/issues/93."""
-    record = _make_repo_data_record(subdir="noarch", noarch="python")
-
-    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
-        RepodataPatchDiff()
-    )
-    assert build_repodata_patch_diff(
-        record, _make_index_json(record, noarch=None)
-    ).metadata == (CompareRow(label="noarch", left="", right="python", changed=True),)
-    assert build_repodata_patch_diff(
-        record, _make_index_json(record, noarch="generic")
-    ).metadata == (
-        CompareRow(label="noarch", left="generic", right="python", changed=True),
-    )
-
-
-def test_build_repodata_patch_diff_reports_patched_python_site_packages_path() -> None:
-    record = _make_repo_data_record(
-        name="python",
-        python_site_packages_path="lib/python3.13t/site-packages",
-    )
-
-    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
-        RepodataPatchDiff()
-    )
-    assert build_repodata_patch_diff(
-        record, _make_index_json(record, python_site_packages_path=None)
-    ).metadata == (
-        CompareRow(
-            label="python_site_packages_path",
-            left="",
-            right="lib/python3.13t/site-packages",
-            changed=True,
-        ),
-    )
-
-
-def test_build_repodata_patch_diff_reports_patched_flags() -> None:
-    record = _make_repo_data_record(flags=["optional"])
-
-    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
-        RepodataPatchDiff()
-    )
-    assert build_repodata_patch_diff(
-        record, _make_index_json(record, flags=[])
-    ).metadata == (CompareRow(label="flags", left="", right="optional", changed=True),)
-
-
-def test_build_repodata_patch_diff_reports_patched_extra_depends() -> None:
-    record = _make_repo_data_record(
-        extra_depends={
-            "scientific": ["numpy >=1.26,<2", "scipy"],
-            "security": ["cryptography >=42"],
-        },
-    )
-
-    assert build_repodata_patch_diff(record, _make_index_json(record)) == (
-        RepodataPatchDiff()
-    )
-    diff = build_repodata_patch_diff(
-        record,
-        _make_index_json(
-            record,
-            extra_depends={"scientific": ["numpy >=1.26"], "docs": ["sphinx"]},
-        ),
-    )
-
-    assert diff.metadata == ()
-    assert diff.dependencies == (
-        CompareRow(label="extra_depends[docs]", left="sphinx", right="", changed=True),
-        CompareRow(
-            label="extra_depends[scientific]",
-            left="numpy >=1.26",
-            right="numpy >=1.26,<2",
-            changed=True,
-        ),
-        CompareRow(
-            label="extra_depends[scientific]", left="", right="scipy", changed=True
-        ),
-        CompareRow(
-            label="extra_depends[security]",
-            left="",
-            right="cryptography >=42",
-            changed=True,
-        ),
     )
 
 


### PR DESCRIPTION
closes #93 

## Summary
This PR adds support for comparing additional package metadata fields when detecting repodata patches: `noarch`, `python_site_packages_path`, `flags`, and `extra_depends`. These fields are now properly exposed by py-rattler and can be compared between the unpatched record and the patched index.json.

## Key Changes
- **Extended scalar field comparison**: Added `noarch`, `python_site_packages_path`, and `flags` to the list of scalar fields compared in `build_repodata_patch_diff()`
- **Extra dependencies support**: Implemented comparison of `extra_depends` groups, which are compared per-group (e.g., `extra_depends[scientific]`, `extra_depends[security]`)
- **NoArchType rendering**: Added proper handling of `NoArchType` in `_repodata_field_text()` to render it as "python", "generic", or empty string
- **Test coverage**: Added comprehensive regression tests for:
  - `noarch` field patching
  - `python_site_packages_path` field patching
  - `flags` field patching
  - `extra_depends` group patching with per-group comparison
- **Test helper updates**: Extended `_make_repo_data_record()` and `_make_index_json()` test helpers to support the new fields

## Implementation Details
- The `extra_depends` comparison iterates through all groups present in either the unpatched or patched metadata, ensuring no groups are missed
- Each dependency within an extra group is compared individually, allowing fine-grained diff reporting
- The `noarch` field uses `NoArchType` which has `python` and `generic` boolean properties for proper rendering
- All new fields follow the existing pattern of comparing unpatched (index.json) vs patched (record) values

https://claude.ai/code/session_01Ty3jTgjxGCCGDShXPYjAVu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repodata comparisons now detect differences in additional package metadata, including no-architecture settings, Python site-package paths, flags, and grouped extra dependencies.
  * Comparison output now displays no-architecture values clearly as Python, generic, or blank.
  * Improved reporting for package metadata differences with expanded regression coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->