### PR TITLE
Make demo video a full link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 An interactive terminal UI for browsing conda package metadata.
 Explore packages, versions, dependencies, and more from any conda channel — right from your terminal.
 
-![pixi-browse demo](.github/assets/demo-dark.gif#gh-dark-mode-only)
-![pixi-browse demo](.github/assets/demo-light.gif#gh-light-mode-only)
+![pixi-browse demo](https://raw.githubusercontent.com/pavelzw/pixi-browse/refs/heads/main/.github/assets/demo-dark.gif#gh-dark-mode-only)
+![pixi-browse demo](https://raw.githubusercontent.com/pavelzw/pixi-browse/refs/heads/main/.github/assets/demo-light.gif#gh-light-mode-only)
 
 ## Features
 


### PR DESCRIPTION
right now, it doesn't show up on pypi

<img width="839" height="689" alt="image" src="https://github.com/user-attachments/assets/7add4e2c-d7eb-47cc-94d8-d5747f0dc5a2" />
