### PR TITLE
Read Pixi configuration with py-rattler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,11 @@ package.
 ## Usage
 
 ```bash
-# Browse conda-forge across all platforms (default)
+# Browse configured default channels (conda-forge if unset) across all platforms
 pixi-browse
+
+# Read a specific config file
+pixi-browse --config ./config.toml
 
 # Browse a different channel
 pixi-browse -c https://prefix.dev/conda-forge
@@ -86,13 +89,42 @@ pixi-browse --version
 
 ### CLI Options
 
-| Option              | Description                                                               |
-| ------------------- | ------------------------------------------------------------------------- |
-| `-c`, `--channel`   | Channels to load at startup (repeat for multiple; default: `conda-forge`) |
-| `-p`, `--platform`  | Platforms to include (repeat for multiple)                                |
-| `-m`, `--matchspec` | MatchSpec query to apply at startup                                       |
-| `--version`         | Show version and exit                                                     |
-| `--help`            | Show help and exit                                                        |
+| Option              | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| `-c`, `--channel`   | Startup channels (repeat for multiple; overrides configured defaults) |
+| `--config`          | Config file to read instead of the default locations                  |
+| `-p`, `--platform`  | Platforms to include (repeat for multiple)                            |
+| `-m`, `--matchspec` | MatchSpec query to apply at startup                                   |
+| `--version`         | Show version and exit                                                 |
+| `--help`            | Show help and exit                                                    |
+
+### Configuration
+
+Without `--config`, pixi-browse loads Pixi's default configuration locations
+through rattler, including shared rattler configuration. These include system
+configuration, the platform's user configuration directory (and
+`XDG_CONFIG_HOME`), and `$PIXI_HOME/config.toml` or `~/.pixi/config.toml`.
+Later files override earlier ones; missing default files are skipped.
+`--config <path>` reads only that file and reports missing or invalid files.
+
+```toml
+default-channels = ["conda-forge", "bioconda"]
+
+[mirrors]
+"https://conda.anaconda.org/conda-forge" = ["https://prefix.dev/conda-forge"]
+
+[repodata-config]
+disable-sharded = true
+```
+
+The shared network client applies mirrors, S3 options, authentication, proxy,
+and TLS settings to repodata, package previews, and downloads. Repodata format
+settings (including per-channel overrides) and `concurrency.downloads` are
+applied to both gateways. Who-needs queries always disable sharded repodata
+because they scan the full channel.
+
+Explicit `-c` flags replace `default-channels`. If neither is set, pixi-browse
+uses `conda-forge`.
 
 ## Keybindings
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -288,7 +288,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarl-1.24.5-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
       - conda_source: pixi-browse[ff462651] @ .
-      - conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[718588e9] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       osx-64:
@@ -498,7 +498,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zizmor-1.28.0-h19f9e61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - conda_source: pixi-browse[9f5af371] @ .
-      - conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[ff8afbe6] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       osx-arm64:
@@ -708,7 +708,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zizmor-1.28.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: pixi-browse[2ab0674f] @ .
-      - conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[5ef4c3b0] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       win-64:
@@ -895,7 +895,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: pixi-browse[e316aef4] @ .
-      - conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[26c12d81] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
   py313:
@@ -1112,7 +1112,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uc-micro-py-2.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
       - conda_source: pixi-browse[ff462651] @ .
-      - conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[718588e9] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       osx-64:
@@ -1274,7 +1274,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.24.5-py313h035b7d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - conda_source: pixi-browse[9f5af371] @ .
-      - conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[ff8afbe6] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       osx-arm64:
@@ -1436,7 +1436,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.24.5-py313h65a2061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: pixi-browse[2ab0674f] @ .
-      - conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[5ef4c3b0] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       win-64:
@@ -1576,7 +1576,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: pixi-browse[e316aef4] @ .
-      - conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[26c12d81] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
   py314:
@@ -1795,7 +1795,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarl-1.24.5-pyh7db6752_0.conda
       - conda_source: pixi-browse[ff462651] @ .
-      - conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[718588e9] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       osx-64:
@@ -1959,7 +1959,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - conda_source: pixi-browse[9f5af371] @ .
-      - conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[ff8afbe6] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       osx-arm64:
@@ -2123,7 +2123,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - conda_source: pixi-browse[2ab0674f] @ .
-      - conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[5ef4c3b0] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
       win-64:
@@ -2265,7 +2265,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda_source: pixi-browse[e316aef4] @ .
-      - conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+      - conda_source: py-rattler[26c12d81] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
       - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/c7/8cd6b5fa8cc4a5c025d3d36a014dff44436fda8b3003a471253931c77f1b/syrupy-4.8.0-py3-none-any.whl
 packages:
@@ -2405,7 +2405,6 @@ packages:
   - libgcc >=14
   license: bzip2-1.0.6
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - bzip2 >=1.0.8,<2.0a0
@@ -2843,7 +2842,6 @@ packages:
   - libgcc >=14
   license: MIT
   license_family: MIT
-  purls: []
   run_exports:
     weak:
     - icu >=78.3,<79.0a0
@@ -3178,7 +3176,6 @@ packages:
   - libgcc >=15
   license: MIT
   license_family: MIT
-  purls: []
   run_exports:
     weak:
     - libffi >=3.7.0,<3.8.0a0
@@ -3266,7 +3263,6 @@ packages:
   - libgomp 16.2.0 he0feb66_4
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  purls: []
   run_exports: {}
   size: 1058083
   timestamp: 1787618680111
@@ -3368,7 +3364,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  purls: []
   run_exports:
     strong:
     - _openmp_mutex >=4.5
@@ -3521,7 +3516,6 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
-  purls: []
   run_exports:
     weak:
     - liblzma >=5.8.3,<6.0a0
@@ -3964,7 +3958,6 @@ packages:
   - libgcc >=15
   - libzlib >=1.3.2,<2.0a0
   license: blessing
-  purls: []
   run_exports:
     weak:
     - libsqlite >=3.53.4,<4.0a0
@@ -4007,7 +4000,6 @@ packages:
   - libstdcxx-ng ==16.2.0=*_4
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  purls: []
   run_exports: {}
   size: 6613148
   timestamp: 1787618704262
@@ -4378,7 +4370,6 @@ packages:
   - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
-  purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
@@ -4559,7 +4550,6 @@ packages:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   license: X11 AND BSD-3-Clause
-  purls: []
   run_exports:
     weak:
     - ncurses >=6.6,<7.0a0
@@ -4677,7 +4667,6 @@ packages:
   - libgcc >=15
   license: Apache-2.0
   license_family: Apache
-  purls: []
   run_exports:
     weak:
     - openssl >=3.6.4,<4.0a0
@@ -5027,7 +5016,6 @@ packages:
   - ncurses >=6.6,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
-  purls: []
   run_exports:
     weak:
     - readline >=8.3,<9.0a0
@@ -5268,7 +5256,6 @@ packages:
   constrains:
   - xorg-libx11 >=1.8.13,<2.0a0
   license: TCL
-  purls: []
   run_exports:
     weak:
     - tk >=8.6.13,<8.7.0a0
@@ -5356,19 +5343,19 @@ packages:
   run_exports: {}
   size: 20873084
   timestamp: 1784709345198
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.7-h86a270d_0.conda
-  sha256: fdd3fc7b02dfcf0a357cd5596910e6f2696d27873f8bcac2f83d2c4db365b6e9
-  md5: 14a917c8e21f3faa2fabb8a761b793dc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.8-h86a270d_0.conda
+  sha256: 9e4bcd3beeebebaf43a693438642ade7ddfd34d265398f6b8e07398f33767dec
+  md5: 14825dfe9cb93713a2eedfefbf15cd11
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=15
   - libstdcxx >=15
+  - libgcc >=15
   constrains:
   - __glibc >=2.17
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 17514479
-  timestamp: 1787888308931
+  size: 17592253
+  timestamp: 1788240832085
 - conda: https://conda.anaconda.org/conda-forge/linux-64/vhs-0.11.0-hfc2019e_0.conda
   sha256: fd97747ac2fb67ad9e61d81169b977e4cb7fa945f8145181420df3c01272781e
   md5: 30057aefb8d8754d45bbacc9a4b14361
@@ -5708,7 +5695,6 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - zstd >=1.5.7,<1.6.0a0
@@ -7388,7 +7374,6 @@ packages:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - bzip2 >=1.0.8,<2.0a0
@@ -8039,7 +8024,6 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  purls: []
   run_exports: {}
   size: 576296
   timestamp: 1787699413070
@@ -8115,7 +8099,6 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  purls: []
   run_exports:
     weak:
     - libffi >=3.7.0,<3.8.0a0
@@ -8243,7 +8226,6 @@ packages:
   depends:
   - __osx >=11.0
   license: LGPL-2.1-only
-  purls: []
   run_exports:
     weak:
     - libiconv >=1.18,<2.0a0
@@ -8344,7 +8326,6 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
-  purls: []
   run_exports:
     weak:
     - liblzma >=5.8.3,<6.0a0
@@ -8681,7 +8662,6 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.2,<2.0a0
   license: blessing
-  purls: []
   run_exports:
     weak:
     - libsqlite >=3.53.4,<4.0a0
@@ -8904,7 +8884,6 @@ packages:
   - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
-  purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
@@ -9105,7 +9084,6 @@ packages:
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
-  purls: []
   run_exports:
     weak:
     - ncurses >=6.6,<7.0a0
@@ -9190,7 +9168,6 @@ packages:
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  purls: []
   run_exports:
     weak:
     - openssl >=3.6.4,<4.0a0
@@ -9468,7 +9445,6 @@ packages:
   - ncurses >=6.6,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
-  purls: []
   run_exports:
     weak:
     - readline >=8.3,<9.0a0
@@ -9693,7 +9669,6 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.2,<2.0a0
   license: TCL
-  purls: []
   run_exports:
     weak:
     - tk >=8.6.13,<8.7.0a0
@@ -9772,9 +9747,9 @@ packages:
   run_exports: {}
   size: 19819576
   timestamp: 1784709667771
-- conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.12.7-h6c1caad_0.conda
-  sha256: 73787b5debc61389604122e3839bb6a54c847ca7d64aad263e513ca5074851bd
-  md5: fe54c3deb5848ca5222160ab3f6b50d4
+- conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.12.8-h6c1caad_0.conda
+  sha256: a182954ce9041fff298b2d044ff3b99f0a82db052051b6b2c56ab4a1bb66929a
+  md5: 0eb8c3c977d4a4c40cd38d0a8e57b4dd
   depends:
   - __osx >=11.0
   - libcxx >=21
@@ -9782,8 +9757,8 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 16414759
-  timestamp: 1787888537908
+  size: 16395089
+  timestamp: 1788240917544
 - conda: https://conda.anaconda.org/conda-forge/osx-64/vhs-0.11.0-h5839d16_0.conda
   sha256: 86d3e81dfcb11e5576e8b7117bab9e86ecb8399eff3075a8e46692acb891ed84
   md5: 5c549f403cd21f5ce1c5e41a4a8b602c
@@ -9887,7 +9862,6 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - zstd >=1.5.7,<1.6.0a0
@@ -9973,7 +9947,6 @@ packages:
   - __osx >=11.0
   license: bzip2-1.0.6
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - bzip2 >=1.0.8,<2.0a0
@@ -10419,7 +10392,6 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  purls: []
   run_exports:
     weak:
     - icu >=78.3,<79.0a0
@@ -10638,7 +10610,6 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  purls: []
   run_exports: {}
   size: 575940
   timestamp: 1787698697875
@@ -10714,7 +10685,6 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  purls: []
   run_exports:
     weak:
     - libffi >=3.7.0,<3.8.0a0
@@ -10854,7 +10824,6 @@ packages:
   depends:
   - __osx >=11.0
   license: LGPL-2.1-only
-  purls: []
   run_exports:
     weak:
     - libiconv >=1.18,<2.0a0
@@ -10943,7 +10912,6 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
-  purls: []
   run_exports:
     weak:
     - liblzma >=5.8.3,<6.0a0
@@ -11280,7 +11248,6 @@ packages:
   - icu >=78.3,<79.0a0
   - libzlib >=1.3.2,<2.0a0
   license: blessing
-  purls: []
   run_exports:
     weak:
     - libsqlite >=3.53.4,<4.0a0
@@ -11503,7 +11470,6 @@ packages:
   - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
-  purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
@@ -11709,7 +11675,6 @@ packages:
   depends:
   - __osx >=11.0
   license: X11 AND BSD-3-Clause
-  purls: []
   run_exports:
     weak:
     - ncurses >=6.6,<7.0a0
@@ -11796,7 +11761,6 @@ packages:
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
-  purls: []
   run_exports:
     weak:
     - openssl >=3.6.4,<4.0a0
@@ -12095,7 +12059,6 @@ packages:
   - ncurses >=6.6,<7.0a0
   license: GPL-3.0-only
   license_family: GPL
-  purls: []
   run_exports:
     weak:
     - readline >=8.3,<9.0a0
@@ -12305,7 +12268,6 @@ packages:
   - __osx >=11.0
   - libzlib >=1.3.2,<2.0a0
   license: TCL
-  purls: []
   run_exports:
     weak:
     - tk >=8.6.13,<8.7.0a0
@@ -12384,18 +12346,18 @@ packages:
   run_exports: {}
   size: 18394718
   timestamp: 1784709318233
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.7-h0e72303_0.conda
-  sha256: 29261168570b4ed7d22025a113ba82e567032833ab649b4e8cdde938a00865ac
-  md5: 7b83e66f8abdddc33929a86da85af273
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.8-h0e72303_0.conda
+  sha256: b1bf36893b4ddd01c88f49951d0047f3f7ba97070fc4b7c3a7c07407b8399a0c
+  md5: af33f385b2afb10c69aa6299bddaa147
   depends:
-  - __osx >=11.0
   - libcxx >=21
+  - __osx >=11.0
   constrains:
   - __osx >=11.0
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 14924131
-  timestamp: 1787888267693
+  size: 14657544
+  timestamp: 1788240782621
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vhs-0.11.0-hf76c51c_0.conda
   sha256: 95386ab310d67b43151a4d46df12ffacafc1ffc6842d3420cb7aa99b012419e0
   md5: 50667b9ec67f9acf76b02897f38e767b
@@ -12498,7 +12460,6 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - zstd >=1.5.7,<1.6.0a0
@@ -12588,7 +12549,6 @@ packages:
   - vc14_runtime >=14.44.35208
   license: bzip2-1.0.6
   license_family: BSD
-  purls: []
   run_exports:
     weak:
     - bzip2 >=1.0.8,<2.0a0
@@ -13063,7 +13023,6 @@ packages:
   - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
-  purls: []
   run_exports:
     weak:
     - libffi >=3.7.0,<3.8.0a0
@@ -13278,7 +13237,6 @@ packages:
   constrains:
   - xz 5.8.3.*
   license: 0BSD
-  purls: []
   run_exports:
     weak:
     - liblzma >=5.8.3,<6.0a0
@@ -13387,7 +13345,6 @@ packages:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: blessing
-  purls: []
   run_exports:
     weak:
     - libsqlite >=3.53.4,<4.0a0
@@ -13552,7 +13509,6 @@ packages:
   - zlib 1.3.2 *_3
   license: Zlib
   license_family: Other
-  purls: []
   run_exports:
     weak:
     - libzlib >=1.3.2,<2.0a0
@@ -13786,7 +13742,6 @@ packages:
   - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: Apache
-  purls: []
   run_exports:
     weak:
     - openssl >=3.6.4,<4.0a0
@@ -14248,7 +14203,6 @@ packages:
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: TCL
-  purls: []
   run_exports:
     weak:
     - tk >=8.6.13,<8.7.0a0
@@ -14306,17 +14260,17 @@ packages:
   run_exports: {}
   size: 21933266
   timestamp: 1784709456379
-- conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.12.7-hc31ddbc_0.conda
-  sha256: a434f936e5aa4b248c9d098204a0e65e7c3760adc0e44b161779db0cc91a76f7
-  md5: de00482a3f33d0982c9f61e282f16362
+- conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.12.8-hc31ddbc_0.conda
+  sha256: d2edbd4cf6fa456a94c48ce310cb5dee58c8379728ff80a998736250c8c53713
+  md5: c160aed447357e603415c27b12dd4af6
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: Apache-2.0 OR MIT
   run_exports: {}
-  size: 15645482
-  timestamp: 1787888335535
+  size: 15690034
+  timestamp: 1788240864864
 - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_39.conda
   sha256: 17693b60cb54f80c60275f003f3bfc1b128af56dbfd65c4fae37c64eeb755ce1
   md5: 2eacea63f545b97342da520df6854276
@@ -14339,7 +14293,6 @@ packages:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
-  purls: []
   run_exports: {}
   size: 21383
   timestamp: 1785359368566
@@ -14367,7 +14320,6 @@ packages:
   - vs2015_runtime 14.51.36247.* *_41
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  purls: []
   run_exports: {}
   size: 767955
   timestamp: 1785359364369
@@ -14395,7 +14347,6 @@ packages:
   - vs2015_runtime 14.51.36247.* *_41
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
-  purls: []
   run_exports:
     strong:
     - vcomp14 >=14.51.36247
@@ -14738,7 +14689,53 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-- conda_source: py-rattler[289c8900] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+- conda_source: py-rattler[26c12d81] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
+  version: 0.25.0
+  build: he01afda_0
+  subdir: win-64
+  variants:
+    c_compiler: vs2022
+    target_platform: win-64
+  depends:
+  - python >=3.10
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  license: BSD-3-Clause
+  build_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.97.1-h17fc481_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.97.1-hf8d6059_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/rust_win-64-1.97.1-ha913c02_2.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_41.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vs_win-64-2022.14-ha74f236_41.conda
+  host_packages:
+  - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.10.21-py310hd8ed1ab_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python-abi3-3.10-h05e3ecb_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.21-hd8ed1ab_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.15.0-py310h3db816d_1.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.4-hf411b9b_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.21-hc20f281_0_cpython.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.12.8-hc31ddbc_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
+  - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+- conda_source: py-rattler[5ef4c3b0] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
   version: 0.25.0
   build: hea27dcd_0
   subdir: osx-arm64
@@ -14811,8 +14808,8 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.21-hac0b6dc_0_cpython.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.7-h0e72303_0.conda
-- conda_source: py-rattler[b1034077] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+  - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.12.8-h0e72303_0.conda
+- conda_source: py-rattler[718588e9] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
   version: 0.25.0
   build: ha35fb5c_0
   subdir: linux-64
@@ -14872,7 +14869,7 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.21-h267e890_0_cpython.conda
   - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
   - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.7-h86a270d_0.conda
+  - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.12.8-h86a270d_0.conda
   - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
@@ -14882,7 +14879,7 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
   - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-- conda_source: py-rattler[c6c76cff] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
+- conda_source: py-rattler[ff8afbe6] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#e15836fcf244d80fc774fc79fceda3bfb748b380
   version: 0.25.0
   build: h4778241_0
   subdir: osx-64
@@ -14954,53 +14951,7 @@ packages:
   - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.21-hea035f4_0_cpython.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
   - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.12.7-h6c1caad_0.conda
-- conda_source: py-rattler[f5baa974] @ git+https://github.com/conda/rattler?subdirectory=py-rattler&branch=main#3530e06250d80d789c7c9fd93c81ff1bcb9f318f
-  version: 0.25.0
-  build: he01afda_0
-  subdir: win-64
-  variants:
-    c_compiler: vs2022
-    target_platform: win-64
-  depends:
-  - python >=3.10
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - _python_abi3_support 1.*
-  - cpython >=3.10
-  license: BSD-3-Clause
-  build_packages:
-  - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.97.1-h17fc481_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.97.1-hf8d6059_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/rust_win-64-1.97.1-ha913c02_2.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_41.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vs_win-64-2022.14-ha74f236_41.conda
-  host_packages:
-  - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-h4c7d964_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.10.21-py310hd8ed1ab_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python-abi3-3.10-h05e3ecb_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.10.21-hd8ed1ab_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.10-8_cp310.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.4.1-pyhcf101f3_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.3-hfd05255_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.53.4-hf5d6505_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.2-hfd05255_3.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.15.0-py310h3db816d_1.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.4-hf411b9b_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.21-hc20f281_0_cpython.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h967ab96_4.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.12.7-hc31ddbc_0.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-ha367084_41.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36247-habf1de7_41.conda
-  - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36247-habf1de7_41.conda
+  - conda: https://conda.anaconda.org/conda-forge/osx-64/uv-0.12.8-h6c1caad_0.conda
 - pypi: https://files.pythonhosted.org/packages/1c/30/c31d800f8d40d663fc84d83548b26aecf613c9c39bd6985c813d623d7b84/pytest_textual_snapshot-1.1.0-py3-none-any.whl
   name: pytest-textual-snapshot
   version: 1.1.0

--- a/pixi_browse/__main__.py
+++ b/pixi_browse/__main__.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import typer
-from rattler.exceptions import InvalidMatchSpecError, ParsePlatformError
+from rattler.config import Config
+from rattler.exceptions import ConfigError, InvalidMatchSpecError, ParsePlatformError
 from rattler.match_spec import MatchSpec
 from rattler.platform import Platform
 
@@ -35,11 +38,16 @@ cli = typer.Typer(
 
 @cli.callback(invoke_without_command=True)
 def run(
-    channel: list[str] = typer.Option(
-        [DEFAULT_CHANNEL],
+    channel: list[str] | None = typer.Option(
+        None,
         "--channel",
         "-c",
-        help="Channels loaded at startup. Repeat the flag to pass multiple channels.",
+        help="Startup channels (repeat for multiple). Defaults to configured channels or conda-forge.",
+    ),
+    config: Path | None = typer.Option(
+        None,
+        "--config",
+        help="Read this config file instead of the default Pixi and rattler locations.",
     ),
     platform: list[str] | None = typer.Option(
         None,
@@ -61,20 +69,37 @@ def run(
         help="Show version and exit.",
     ),
 ) -> None:
-    build_app(channels=channel, platforms=platform, matchspec=matchspec).run()
+    build_app(
+        channels=channel, platforms=platform, matchspec=matchspec, config_path=config
+    ).run()
 
 
 def build_app(
     *,
-    channels: list[str],
+    channels: list[str] | None,
     platforms: list[str] | None,
     matchspec: str | None,
+    config_path: Path | None = None,
+    cache_dir: Path | None = None,
 ) -> CondaMetadataTui:
     """Validate the command line options and build the (not yet running) app.
 
     Exits with status 1 on an unknown platform, an invalid MatchSpec, or when
     no channel is left after dropping blank and repeated ones.
     """
+    try:
+        config = (
+            Config.load_from_files([config_path])
+            if config_path is not None
+            else Config.load_from_default_locations("pixi")
+        )
+    except ConfigError as exc:
+        typer.echo(f"Failed to load configuration: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    if channels is None:
+        channels = config.default_channels
+        if channels is None:
+            channels = [DEFAULT_CHANNEL]
     channel_names = normalize_channel_names(channels)
     if not channel_names:
         typer.echo("At least one channel is required.", err=True)
@@ -100,6 +125,8 @@ def build_app(
         default_channels=channel_names,
         default_platforms=requested_platforms,
         default_matchspec=requested_matchspec,
+        config=config,
+        cache_dir=cache_dir,
     )
 
 

--- a/pixi_browse/repodata.py
+++ b/pixi_browse/repodata.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
 
+from rattler.config import Config
 from rattler.exceptions import GatewayError
 from rattler.match_spec import MatchSpec
 from rattler.networking import Client
@@ -14,7 +16,6 @@ from rattler.repo_data import (
     Gateway,
     PackageRecord,
     RepoDataRecord,
-    SourceConfig,
 )
 
 from pixi_browse.platform_utils import platform_sort_key
@@ -46,15 +47,26 @@ def whoneeds_target_label(target: str | PackageRecord) -> str:
 def create_gateway(
     *,
     client: Client | None = None,
-    sharded_enabled: bool = True,
+    config: Config | None = None,
+    sharded_enabled: bool | None = None,
     cache_dir: Path | None = None,
 ) -> Gateway:
-    return Gateway(
+    config = config if config is not None else Config()
+    if sharded_enabled is not None:
+        # Keep the caller's configuration intact. Override every channel as
+        # well as the default so who-needs always scans unsharded repodata.
+        config = config.merge(Config())
+        disabled = json.dumps(not sharded_enabled)
+        config.set("repodata-config.disable-sharded", disabled)
+        repodata_config: dict[str, object] = config.repodata_config
+        for channel, options in repodata_config.items():
+            if isinstance(options, dict):
+                config.set(
+                    f"repodata-config.{json.dumps(channel)}.disable-sharded", disabled
+                )
+    return Gateway.from_config(
+        config,
         cache_dir=cache_dir,
-        default_config=SourceConfig(
-            sharded_enabled=sharded_enabled,
-            cache_action="cache-or-fetch",
-        ),
         client=client,
         show_progress=False,
     )

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from time import perf_counter
 from typing import Literal, cast
 
+from rattler.config import Config
 from rattler.exceptions import GatewayError
 from rattler.match_spec import MatchSpec
 from rattler.networking import Client
@@ -130,23 +131,28 @@ class CondaMetadataTui(App[None]):
         default_channels: Iterable[str],
         default_platforms: Iterable[Platform] | None = None,
         default_matchspec: MatchSpec | None = None,
+        config: Config | None = None,
         client: Client | None = None,
         cache_dir: Path | None = None,
     ) -> None:
         super().__init__()
         selected_platforms = set(default_platforms or [])
         self.theme = "ansi-dark"
+        config = config if config is not None else Config()
         self._client = (
             client
             if client is not None
-            else Client.default_client(user_agent=f"pixi-browse/{__version__}")
+            else Client.from_config(config, user_agent=f"pixi-browse/{__version__}")
         )
 
         self._gateway: Gateway = create_gateway(
-            client=self._client, cache_dir=cache_dir
+            client=self._client, config=config, cache_dir=cache_dir
         )
         self._whoneeds_gateway: Gateway = create_gateway(
-            client=self._client, sharded_enabled=False, cache_dir=cache_dir
+            client=self._client,
+            config=config,
+            sharded_enabled=False,
+            cache_dir=cache_dir,
         )
         self._platforms: list[Platform] = []
         self._available_platform_names: list[Platform] = []
@@ -227,11 +233,11 @@ class CondaMetadataTui(App[None]):
         Returns the error message when loading fails, ``None`` on success.
         """
         status = self.query_one("#status", Static)
-        status.update("Discovering available platforms via sharded gateway...")
+        status.update("Discovering available platforms...")
         try:
             await self._ensure_available_platforms()
             status.update(
-                f"Downloading repodata for {self._selected_platforms_text()} (sharded)..."
+                f"Downloading repodata for {self._selected_platforms_text()}..."
             )
             self._channel_package_names = await self._fetch_package_names_with_gateway()
         except (GatewayError, RuntimeError) as exc:

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -132,17 +132,14 @@ class CondaMetadataTui(App[None]):
         default_platforms: Iterable[Platform] | None = None,
         default_matchspec: MatchSpec | None = None,
         config: Config | None = None,
-        client: Client | None = None,
         cache_dir: Path | None = None,
     ) -> None:
         super().__init__()
         selected_platforms = set(default_platforms or [])
         self.theme = "ansi-dark"
         config = config if config is not None else Config()
-        self._client = (
-            client
-            if client is not None
-            else Client.from_config(config, user_agent=f"pixi-browse/{__version__}")
+        self._client = Client.from_config(
+            config, user_agent=f"pixi-browse/{__version__}"
         )
 
         self._gateway: Gateway = create_gateway(

--- a/tests/__snapshots__/test_config.ambr
+++ b/tests/__snapshots__/test_config.ambr
@@ -1,0 +1,155 @@
+# serializer version: 1
+# name: test_config_repodata_previews_and_downloads[mirror-False]
+  dict({
+    'about': dict({
+      'channels': list([
+        'https://conda.anaconda.org/conda-forge/',
+      ]),
+      'dev_url': 'https://github.com/pavelzw/pixi-browse',
+      'doc_url': 'https://github.com/pavelzw/pixi-browse',
+      'extra': dict({
+        'flow_run_id': 'github_26884037975',
+        'recipe-maintainers': list([
+          'pavelzw',
+        ]),
+        'remote_url': 'https://github.com/conda-forge/pixi-browse-feedstock',
+        'sha': '94b9f1d564e589aaebc8c4baffff1133d8874690',
+      }),
+      'home': 'https://github.com/pavelzw/pixi-browse',
+      'license': 'BSD-3-Clause',
+      'summary': 'A TUI to browse conda packages',
+    }),
+    'channels': list([
+      'https://config.invalid/conda-forge',
+    ]),
+    'packages': list([
+      'pixi-browse-0.0.14-pyhc364b38_0.conda',
+      'pixi-browse-0.0.13-pyhc364b38_0.conda',
+      'pixi-browse-0.0.12-pyhc364b38_0.conda',
+    ]),
+    'requests': list([
+      '/conda-forge/noarch/pixi-browse-0.0.14-pyhc364b38_0.conda',
+      '/conda-forge/noarch/repodata.json',
+    ]),
+  })
+# ---
+# name: test_config_repodata_previews_and_downloads[mirror-True]
+  dict({
+    'about': dict({
+      'channels': list([
+        'https://conda.anaconda.org/conda-forge/',
+      ]),
+      'dev_url': 'https://github.com/pavelzw/pixi-browse',
+      'doc_url': 'https://github.com/pavelzw/pixi-browse',
+      'extra': dict({
+        'flow_run_id': 'github_26884037975',
+        'recipe-maintainers': list([
+          'pavelzw',
+        ]),
+        'remote_url': 'https://github.com/conda-forge/pixi-browse-feedstock',
+        'sha': '94b9f1d564e589aaebc8c4baffff1133d8874690',
+      }),
+      'home': 'https://github.com/pavelzw/pixi-browse',
+      'license': 'BSD-3-Clause',
+      'summary': 'A TUI to browse conda packages',
+    }),
+    'channels': list([
+      'https://config.invalid/conda-forge',
+    ]),
+    'packages': list([
+      'pixi-browse-0.0.14-pyhc364b38_0.conda',
+      'pixi-browse-0.0.13-pyhc364b38_0.conda',
+      'pixi-browse-0.0.12-pyhc364b38_0.conda',
+    ]),
+    'requests': list([
+      '/conda-forge/noarch/pixi-browse-0.0.14-pyhc364b38_0.conda',
+      '/conda-forge/noarch/repodata.json',
+    ]),
+  })
+# ---
+# name: test_config_repodata_previews_and_downloads[s3-False]
+  dict({
+    'about': dict({
+      'channels': list([
+        'https://conda.anaconda.org/conda-forge/',
+      ]),
+      'dev_url': 'https://github.com/pavelzw/pixi-browse',
+      'doc_url': 'https://github.com/pavelzw/pixi-browse',
+      'extra': dict({
+        'flow_run_id': 'github_26884037975',
+        'recipe-maintainers': list([
+          'pavelzw',
+        ]),
+        'remote_url': 'https://github.com/conda-forge/pixi-browse-feedstock',
+        'sha': '94b9f1d564e589aaebc8c4baffff1133d8874690',
+      }),
+      'home': 'https://github.com/pavelzw/pixi-browse',
+      'license': 'BSD-3-Clause',
+      'summary': 'A TUI to browse conda packages',
+    }),
+    'channels': list([
+      's3://conda-forge',
+    ]),
+    'packages': list([
+      'pixi-browse-0.0.14-pyhc364b38_0.conda',
+      'pixi-browse-0.0.13-pyhc364b38_0.conda',
+      'pixi-browse-0.0.12-pyhc364b38_0.conda',
+    ]),
+    'requests': list([
+      '/conda-forge/noarch/pixi-browse-0.0.14-pyhc364b38_0.conda',
+      '/conda-forge/noarch/repodata.json',
+    ]),
+  })
+# ---
+# name: test_config_repodata_previews_and_downloads[s3-True]
+  dict({
+    'about': dict({
+      'channels': list([
+        'https://conda.anaconda.org/conda-forge/',
+      ]),
+      'dev_url': 'https://github.com/pavelzw/pixi-browse',
+      'doc_url': 'https://github.com/pavelzw/pixi-browse',
+      'extra': dict({
+        'flow_run_id': 'github_26884037975',
+        'recipe-maintainers': list([
+          'pavelzw',
+        ]),
+        'remote_url': 'https://github.com/conda-forge/pixi-browse-feedstock',
+        'sha': '94b9f1d564e589aaebc8c4baffff1133d8874690',
+      }),
+      'home': 'https://github.com/pavelzw/pixi-browse',
+      'license': 'BSD-3-Clause',
+      'summary': 'A TUI to browse conda packages',
+    }),
+    'channels': list([
+      's3://conda-forge',
+    ]),
+    'packages': list([
+      'pixi-browse-0.0.14-pyhc364b38_0.conda',
+      'pixi-browse-0.0.13-pyhc364b38_0.conda',
+      'pixi-browse-0.0.12-pyhc364b38_0.conda',
+    ]),
+    'requests': list([
+      '/conda-forge/noarch/pixi-browse-0.0.14-pyhc364b38_0.conda',
+      '/conda-forge/noarch/repodata.json',
+    ]),
+  })
+# ---
+# name: test_default_locations_read_pixi_home_and_explicit_config_replaces_it
+  list([
+    list([
+      'bioconda',
+      'conda-forge',
+    ]),
+    list([
+      'https://prefix.dev/conda-forge',
+    ]),
+  ])
+# ---
+# name: test_whoneeds_disables_shards_even_with_channel_override
+  list([
+    'libzlib-1.3.1-hb9d3cd8_2.conda',
+    'libzlib-1.3.2-h25fd6f3_3.conda',
+    'zlib-1.3.1-hb9d3cd8_2.conda',
+  ])
+# ---

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,7 @@ The channel consists of real conda-forge artifacts listed in
 downloads them into a git-ignored directory on first use and verifies their
 hashes. At session start the directory is indexed with py-rattler and served by
 a small HTTP server that supports range requests, the same way a real channel
-mirror would. A rattler ``Client`` with a
-``MirrorMiddleware`` then transparently redirects every request for
+mirror would. A rattler ``Config`` with local mirrors then redirects every request for
 ``https://conda.anaconda.org/conda-forge/`` to that server, so the app can be
 started with its production defaults (``conda-forge``) and exercises the exact
 gateway, repodata, package-streaming and rendering code paths it uses for
@@ -21,6 +20,7 @@ it fails.
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 import threading
 from collections.abc import Iterable, Iterator
@@ -29,10 +29,10 @@ from http.server import ThreadingHTTPServer
 from pathlib import Path
 
 import pytest
+from rattler.config import Config
 from rattler.index import index_fs
 from rattler.match_spec import MatchSpec
 from rattler.networking import Client
-from rattler.networking.middleware import MirrorMiddleware
 from rattler.platform import Platform
 from rattler.repo_data import Gateway
 
@@ -87,8 +87,8 @@ def channel_server(fixture_channels_dir: Path) -> Iterator[str]:
 
 
 @pytest.fixture(scope="session")
-def rattler_client(channel_manifest: ChannelManifest, channel_server: str) -> Client:
-    """A rattler client that serves the test channels from the local server
+def rattler_config(channel_manifest: ChannelManifest, channel_server: str) -> Config:
+    """Configure the test channels to be served from the local server
     under the URLs the app resolves their names to."""
     mirrors = {
         f"{channel_url}/": [f"{channel_server}{channel_name}/"]
@@ -98,10 +98,15 @@ def rattler_client(channel_manifest: ChannelManifest, channel_server: str) -> Cl
         f"{channel_server}{MISSING_CHANNEL}/"
     ]
     assert f"{ANACONDA_CHANNELS_URL}{MAIN_CHANNEL}/" in mirrors
-    return Client(
-        middlewares=[MirrorMiddleware(mirrors)],
-        user_agent="pixi-browse-tests",
-    )
+    config = Config()
+    config.set("mirrors", json.dumps(mirrors))
+    return config
+
+
+@pytest.fixture(scope="session")
+def rattler_client(rattler_config: Config) -> Client:
+    """Use the same configuration for direct package-streaming tests."""
+    return Client.from_config(rattler_config, user_agent="pixi-browse-tests")
 
 
 @pytest.fixture
@@ -111,10 +116,10 @@ def rattler_cache_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-def make_gateway(rattler_client: Client, rattler_cache_dir: Path) -> GatewayFactory:
+def make_gateway(rattler_config: Config, rattler_cache_dir: Path) -> GatewayFactory:
     def factory(*, sharded_enabled: bool = True) -> Gateway:
         return create_gateway(
-            client=rattler_client,
+            config=rattler_config,
             sharded_enabled=sharded_enabled,
             cache_dir=rattler_cache_dir,
         )
@@ -123,7 +128,7 @@ def make_gateway(rattler_client: Client, rattler_cache_dir: Path) -> GatewayFact
 
 
 @pytest.fixture
-def make_app(rattler_client: Client, rattler_cache_dir: Path) -> AppFactory:
+def make_app(rattler_config: Config, rattler_cache_dir: Path) -> AppFactory:
     """Build the real app against the fixture channel."""
 
     def factory(
@@ -136,7 +141,7 @@ def make_app(rattler_client: Client, rattler_cache_dir: Path) -> AppFactory:
             default_channels=default_channels,
             default_platforms=default_platforms,
             default_matchspec=default_matchspec,
-            client=rattler_client,
+            config=rattler_config,
             cache_dir=rattler_cache_dir,
         )
 

--- a/tests/test_channel_data.py
+++ b/tests/test_channel_data.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from rattler.config import Config
 from rattler.exceptions import GatewayError
 from rattler.match_spec import MatchSpec
 from rattler.networking import Client
@@ -363,14 +364,13 @@ def test_load_version_artifact_data_is_cached_per_preview_key(
     assert first.dependencies == ("python >=3.9",)
 
 
-def test_app_shares_the_client_with_its_version_loader(rattler_client: Client) -> None:
-    app = CondaMetadataTui(default_channels=["conda-forge"], client=rattler_client)
+def test_app_shares_the_client_with_its_version_loader(rattler_config: Config) -> None:
+    app = CondaMetadataTui(default_channels=["conda-forge"], config=rattler_config)
 
-    assert app._client is rattler_client
-    assert app._version_loader._client is rattler_client
+    assert app._version_loader._client is app._client
 
 
-def test_app_creates_a_default_client_when_none_is_given() -> None:
+def test_app_creates_a_default_client_without_config() -> None:
     app = CondaMetadataTui(default_channels=["conda-forge"])
 
     assert isinstance(app._client, Client)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 
 import pytest
 from rattler.match_spec import MatchSpec
@@ -25,6 +26,7 @@ def test_help_includes_expected_options() -> None:
     assert "--channel" in output
     assert "--matchspec" in output
     assert "--platform" in output
+    assert "--config" in output
     assert "--version" in output
 
 
@@ -63,14 +65,15 @@ def test_build_app_keeps_channel_order_and_drops_repeats() -> None:
     assert app._channel_names == ["bioconda", "conda-forge"]
 
 
-def test_cli_defaults_the_channel_option_to_conda_forge() -> None:
+def test_cli_documents_configured_channel_defaults() -> None:
     runner = CliRunner()
 
     result = runner.invoke(entrypoint.cli, ["--help"])
     output = strip_ansi(result.output)
 
     assert result.exit_code == 0
-    assert re.search(r"default:\s+conda-forge", output)
+    assert "configured channels" in output
+    assert "conda-forge" in output
 
 
 def test_cli_exits_without_any_channel() -> None:
@@ -119,3 +122,50 @@ def test_cli_exits_for_invalid_matchspec() -> None:
 
     assert result.exit_code == 1
     assert result.output.strip()
+
+
+@pytest.mark.parametrize(
+    "contents", [None, "default-channels = [", "default-channels = 42"]
+)
+def test_cli_exits_for_invalid_config(tmp_path: Path, contents: str | None) -> None:
+    path = tmp_path / "config.toml"
+    if contents is not None:
+        path.write_text(contents)
+
+    result = CliRunner().invoke(entrypoint.cli, ["--config", str(path)])
+
+    assert result.exit_code == 1
+    assert "Failed to load configuration:" in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.parametrize(
+    ("contents", "channels", "expected"),
+    [
+        ("", None, ["conda-forge"]),
+        (
+            'default-channels = ["bioconda", "conda-forge"]',
+            None,
+            ["bioconda", "conda-forge"],
+        ),
+        ('default-channels = ["bioconda"]', ["conda-forge"], ["conda-forge"]),
+        ('default-channels = ["bioconda", " bioconda ", ""]', None, ["bioconda"]),
+    ],
+)
+def test_config_channel_precedence(
+    tmp_path: Path, contents: str, channels: list[str] | None, expected: list[str]
+) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text(contents)
+    app = entrypoint.build_app(
+        channels=channels, platforms=None, matchspec=None, config_path=path
+    )
+    assert app._channel_names == expected
+
+
+def test_cli_rejects_empty_configured_channels(tmp_path: Path) -> None:
+    path = tmp_path / "config.toml"
+    path.write_text("default-channels = []")
+    result = CliRunner().invoke(entrypoint.cli, ["--config", str(path)])
+    assert result.exit_code == 1
+    assert "At least one channel is required." in result.output

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,201 @@
+"""Configuration integration tests using real channel data and HTTP requests."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import threading
+from collections.abc import Iterator
+from functools import partial
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import override
+
+import pytest
+from rattler.config import Config
+from rattler.package_streaming import download_to_path, fetch_raw_package_file_from_url
+from rattler.platform import Platform
+from syrupy.assertion import SnapshotAssertion
+
+from pixi_browse.__main__ import build_app
+from pixi_browse.repodata import create_gateway, query_package_records
+from tests.helpers import RangeRequestHandler
+
+
+@pytest.fixture
+def recording_channel_server(
+    fixture_channels_dir: Path,
+) -> Iterator[tuple[str, list[str]]]:
+    requests: list[str] = []
+
+    class Handler(RangeRequestHandler):
+        @override
+        def do_GET(self) -> None:
+            requests.append(self.path.split("?", 1)[0])
+            super().do_GET()
+
+    server = ThreadingHTTPServer(
+        ("127.0.0.1", 0), partial(Handler, directory=str(fixture_channels_dir))
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.parametrize("per_channel", [False, True])
+@pytest.mark.parametrize("transport", ["mirror", "s3"])
+def test_config_repodata_previews_and_downloads(
+    tmp_path: Path,
+    recording_channel_server: tuple[str, list[str]],
+    snapshot: SnapshotAssertion,
+    per_channel: bool,
+    transport: str,
+) -> None:
+    server_url, requests = recording_channel_server
+    if transport == "s3":
+        upstream = "s3://conda-forge"
+        credentials = tmp_path / "credentials.json"
+        credentials.write_text(
+            json.dumps(
+                {
+                    upstream: {
+                        "S3Credentials": {
+                            "access_key_id": "test-access-key",
+                            "secret_access_key": "test-secret-key",
+                        }
+                    }
+                }
+            )
+        )
+        network_config = f'''
+authentication-override-file = {json.dumps(str(credentials))}
+[s3-options.conda-forge]
+endpoint-url = "{server_url}"
+region = "us-east-1"
+force-path-style = true
+'''
+    else:
+        upstream = "https://config.invalid/conda-forge"
+        network_config = f'''
+[mirrors]
+"{upstream}" = ["{server_url}/conda-forge"]
+'''
+    scope = f'repodata-config."{upstream}"' if per_channel else "repodata-config"
+    path = tmp_path / "config.toml"
+    path.write_text(f'''
+default-channels = ["{upstream}"]
+{network_config}
+[{scope}]
+disable-sharded = true
+disable-zstd = true
+disable-bzip2 = true
+''')
+    app = build_app(
+        channels=None,
+        platforms=["noarch"],
+        matchspec=None,
+        config_path=path,
+        cache_dir=tmp_path / "cache",
+    )
+
+    async def run() -> dict[str, object]:
+        records = await query_package_records(
+            gateway=app._gateway,
+            channel_names=app._channel_names,
+            platforms=[Platform("noarch")],
+            package_name="pixi-browse",
+        )
+        record = records[0]
+        preview = await fetch_raw_package_file_from_url(
+            app._client, record.url, "info/about.json"
+        )
+        destination = tmp_path / record.file_name
+        await download_to_path(app._client, record.url, destination)
+        assert hashlib.sha256(destination.read_bytes()).digest() == record.sha256
+        return {
+            "channels": app._channel_names,
+            "packages": [record.file_name for record in records],
+            "about": json.loads(preview),
+            "requests": sorted(set(requests)),
+        }
+
+    assert asyncio.run(run()) == snapshot
+    assert "/conda-forge/noarch/repodata.json" in requests
+    assert not any(
+        "shard" in path or path.endswith((".zst", ".bz2")) for path in requests
+    )
+
+
+def test_whoneeds_disables_shards_even_with_channel_override(
+    tmp_path: Path,
+    recording_channel_server: tuple[str, list[str]],
+    snapshot: SnapshotAssertion,
+) -> None:
+    server_url, requests = recording_channel_server
+    upstream = "https://config.invalid/conda-forge"
+    config = Config.from_toml(f'''
+[mirrors]
+"{upstream}" = ["{server_url}/conda-forge"]
+[repodata-config]
+disable-sharded = false
+disable-zstd = true
+disable-bzip2 = true
+[repodata-config."{upstream}"]
+disable-sharded = false
+''')
+    original = config.to_toml()
+    gateway = create_gateway(
+        config=config, sharded_enabled=False, cache_dir=tmp_path / "cache"
+    )
+    assert config.to_toml() == original
+
+    async def run() -> list[str]:
+        results = await gateway.who_needs(
+            sources=[upstream], platforms=[Platform("linux-64")], target="libzlib"
+        )
+        return sorted({result.record.file_name for result in results})
+
+    assert asyncio.run(run()) == snapshot
+    assert "/conda-forge/linux-64/repodata.json" in requests
+    assert not any("shard" in path for path in requests)
+
+
+def test_default_locations_read_pixi_home_and_explicit_config_replaces_it(
+    tmp_path: Path, snapshot: SnapshotAssertion
+) -> None:
+    # A child process gives rattler a real, isolated PIXI_HOME without
+    # changing the environment of other tests or patching config discovery.
+    pixi_home = tmp_path / "pixi"
+    pixi_home.mkdir()
+    (pixi_home / "config.toml").write_text(
+        'default-channels = ["bioconda", "conda-forge"]'
+    )
+    explicit = tmp_path / "explicit.toml"
+    explicit.write_text('default-channels = ["https://prefix.dev/conda-forge"]')
+    script = """
+import json
+import sys
+from pathlib import Path
+from pixi_browse.__main__ import build_app
+
+default = build_app(channels=None, platforms=None, matchspec=None)
+explicit = build_app(channels=None, platforms=None, matchspec=None, config_path=Path(sys.argv[1]))
+print(json.dumps([default._channel_names, explicit._channel_names]))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(explicit)],
+        env={**os.environ, "PIXI_HOME": str(pixi_home)},
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert json.loads(result.stdout) == snapshot


### PR DESCRIPTION
Reads Pixi and shared rattler configuration at startup, or only the file supplied with `pixi-browse --config <path>`. Configured `default-channels` replace the conda-forge fallback; explicit `-c` flags take precedence. Missing or malformed explicit configuration produces CLI errors.

Uses py-rattler's config-aware client and shared gateway for mirrors, S3, authentication, proxy/TLS settings, repodata formats and per-channel overrides. Preserves #106: who-needs scans full repodata through the same gateway, even when sharding is enabled.

Retains main's locked py-rattler Git revision. The configuration API is unreleased; package metadata still targets the existing 0.25 series and needs updating when the API is released.

Validation:
- `pixi run env -u NO_COLOR pytest -n auto`: 266 passed, including existing TUI snapshots.
- Real-data configuration snapshots cover mirrors, a local S3 endpoint, repodata formats, package previews, checksum-verified downloads, who-needs with sharding enabled, and default configuration discovery.
- `pixi run lint`: passed, including mypy.

Related to #26.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for loading settings from TOML configuration files, including custom paths and default Pixi locations.
  - Added a `--config` CLI option.
  - Configured default channels are now used automatically when no channels are specified.
  - Explicit `--channel` values override configured defaults.
  - Configuration supports mirrors, repodata settings, shared networking, and cache locations.

- **Documentation**
  - Updated usage examples, CLI option descriptions, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->