### PR TITLE
refactor: Remove dead TUI code

### DIFF
--- a/pixi_browse/__main__.py
+++ b/pixi_browse/__main__.py
@@ -130,5 +130,5 @@ def build_app(
     )
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - exercised as a subprocess
     cli()

--- a/pixi_browse/rendering.py
+++ b/pixi_browse/rendering.py
@@ -4,7 +4,6 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import PurePosixPath
-from typing import Any
 from urllib.parse import urlparse
 
 from rattler.exceptions import InvalidMatchSpecError
@@ -137,6 +136,10 @@ def _clickable_recipe_maintainers_value(handles: Sequence[str]) -> str:
     return ", ".join(format_clickable_github_handle(handle) for handle in handles)
 
 
+def _url_list_value(urls: Sequence[str]) -> str:
+    return ", ".join(escape(url) for url in urls)
+
+
 def _clickable_provenance_value(remote_url: str | None, sha: str | None) -> str | None:
     provenance_link = _provenance_link(remote_url, sha)
     if provenance_link is None:
@@ -145,30 +148,7 @@ def _clickable_provenance_value(remote_url: str | None, sha: str | None) -> str 
     return format_clickable_link(escape(label), commit_url)
 
 
-def _format_url_value(url: str, *, clickable: bool) -> str:
-    if clickable:
-        return format_clickable_url(url)
-    return escape(url)
-
-
-def _format_url_list_value(urls: Sequence[str], *, clickable: bool) -> str:
-    if clickable:
-        return _clickable_url_list_value(urls)
-    return ", ".join(escape(url) for url in urls)
-
-
-def _format_recipe_maintainers_value(handles: Sequence[str], *, clickable: bool) -> str:
-    if clickable:
-        return _clickable_recipe_maintainers_value(handles)
-    return ", ".join(escape(handle) for handle in handles)
-
-
-def _format_provenance_value(
-    remote_url: str | None, sha: str | None, *, clickable: bool
-) -> str | None:
-    if clickable:
-        return _clickable_provenance_value(remote_url, sha)
-
+def _provenance_value(remote_url: str | None, sha: str | None) -> str | None:
     provenance_link = _provenance_link(remote_url, sha)
     if provenance_link is None:
         return None
@@ -176,7 +156,7 @@ def _format_provenance_value(
     return escape(label)
 
 
-def format_record_value(value: Any) -> str:
+def format_record_value(value: object) -> str:
     if value is None:
         return "not available"
     if isinstance(value, bytes):
@@ -185,23 +165,15 @@ def format_record_value(value: Any) -> str:
         if not value:
             return "none"
         return ", ".join(str(item) for item in value)
-    if hasattr(value, "isoformat"):
-        try:
-            return value.isoformat()
-        except TypeError:
-            pass
+    if isinstance(value, datetime):
+        return value.isoformat()
     text = str(value)
     if text == "NoArchType(None)":
         return "none"
     return escape(text)
 
 
-def format_byte_size(value: Any) -> str:
-    if value is None:
-        return "not available"
-    if not isinstance(value, int) or value < 0:
-        return format_record_value(value)
-
+def _scale_byte_size(value: int) -> tuple[float, str]:
     units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
     size = float(value)
     unit = units[0]
@@ -210,27 +182,22 @@ def format_byte_size(value: Any) -> str:
         if size < 1024.0 or candidate == units[-1]:
             break
         size /= 1024.0
+    return size, unit
 
+
+def format_byte_size(value: int | None) -> str:
+    """Render a repodata size with the exact byte count, e.g. ``1.5 KiB (1,536 bytes)``."""
+    if value is None:
+        return "not available"
+    size, unit = _scale_byte_size(value)
     if unit == "B":
         return f"{value:,} B"
     return f"{size:.1f} {unit} ({value:,} bytes)"
 
 
-def format_human_byte_size(value: Any) -> str:
-    if value is None:
-        return "not available"
-    if not isinstance(value, int) or value < 0:
-        return format_record_value(value)
-
-    units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB"]
-    size = float(value)
-    unit = units[0]
-    for candidate in units:
-        unit = candidate
-        if size < 1024.0 or candidate == units[-1]:
-            break
-        size /= 1024.0
-
+def format_human_byte_size(value: int) -> str:
+    """Render a file size compactly, e.g. ``1.5 KiB``."""
+    size, unit = _scale_byte_size(value)
     if unit == "B":
         return f"{value:,} B"
     return f"{size:.1f} {unit}"
@@ -316,7 +283,6 @@ def _metadata_rows_for_record(
     package_name: str,
     record: RepoDataRecord,
     *,
-    clickable: bool = False,
     repository_urls: Sequence[str] = (),
     documentation_urls: Sequence[str] = (),
     homepage_urls: Sequence[str] = (),
@@ -351,40 +317,22 @@ def _metadata_rows_for_record(
         ("SHA256", format_record_value(record.sha256)),
         ("Legacy .tar.bz2 MD5", format_record_value(record.legacy_bz2_md5)),
         ("Legacy .tar.bz2 Size", format_byte_size(record.legacy_bz2_size)),
-        ("Package URL", _format_url_value(str(record.url), clickable=clickable)),
+        ("Package URL", escape(str(record.url))),
     ]
     if repository_urls:
-        metadata_rows.append(
-            (
-                "Repository",
-                _format_url_list_value(repository_urls, clickable=clickable),
-            )
-        )
+        metadata_rows.append(("Repository", _url_list_value(repository_urls)))
     if documentation_urls:
-        metadata_rows.append(
-            (
-                "Documentation",
-                _format_url_list_value(documentation_urls, clickable=clickable),
-            )
-        )
+        metadata_rows.append(("Documentation", _url_list_value(documentation_urls)))
     if homepage_urls:
-        metadata_rows.append(
-            ("Homepage", _format_url_list_value(homepage_urls, clickable=clickable))
-        )
+        metadata_rows.append(("Homepage", _url_list_value(homepage_urls)))
     if recipe_maintainers:
         metadata_rows.append(
             (
                 "Recipe maintainers",
-                _format_recipe_maintainers_value(
-                    recipe_maintainers, clickable=clickable
-                ),
+                ", ".join(escape(handle) for handle in recipe_maintainers),
             )
         )
-    provenance_value = _format_provenance_value(
-        provenance_remote_url,
-        provenance_sha,
-        clickable=clickable,
-    )
+    provenance_value = _provenance_value(provenance_remote_url, provenance_sha)
     if provenance_value is not None:
         metadata_rows.append(("Provenance", provenance_value))
     if rattler_build_version:

--- a/pixi_browse/tui/app.py
+++ b/pixi_browse/tui/app.py
@@ -39,9 +39,6 @@ from pixi_browse import __version__
 from pixi_browse.models import (
     CompareFileRow,
     CompareSelection,
-    DependencyTab,
-    FileTab,
-    MetadataTab,
     PackageFile,
     VersionArtifactData,
     VersionEntry,
@@ -79,12 +76,9 @@ from .state import ChannelStateSnapshot
 from .version_loader import VersionDataLoader
 from .widgets import (
     ACTIVE_SECTION_TITLE_STYLE,
-    DEPENDENCY_TABS,
     DIFF_VIEW_AVAILABLE,
     DIFF_VIEW_INSTALL_HINT,
-    FILE_TABS,
     INACTIVE_SECTION_TITLE_STYLE,
-    METADATA_TABS,
     ChannelScreen,
     CompareScreen,
     DownloadPathScreen,
@@ -802,24 +796,6 @@ class CondaMetadataTui(App[None]):
     def _cycle_active_main_section(self, direction: int) -> None:
         self.query_one("#main-panel", MainPanel).cycle_active_section(direction)
 
-    def _set_main_metadata_tab(self, tab: MetadataTab) -> None:
-        self.query_one("#main-panel", MainPanel).set_metadata_tab(tab)
-
-    def _cycle_main_metadata_tab(self, direction: int) -> None:
-        self.query_one("#main-panel", MainPanel).cycle_metadata_tab(direction)
-
-    def _set_main_dependency_tab(self, tab: DependencyTab) -> None:
-        self.query_one("#main-panel", MainPanel).set_dependency_tab(tab)
-
-    def _cycle_main_dependency_tab(self, direction: int) -> None:
-        self.query_one("#main-panel", MainPanel).cycle_dependency_tab(direction)
-
-    def _set_main_file_tab(self, tab: FileTab) -> None:
-        self.query_one("#main-panel", MainPanel).set_file_tab(tab)
-
-    def _cycle_main_file_tab(self, direction: int) -> None:
-        self.query_one("#main-panel", MainPanel).cycle_file_tab(direction)
-
     def _selected_dependency_matchspec(self) -> str | None:
         return self.query_one("#main-panel", MainPanel).selected_dependency_matchspec()
 
@@ -834,15 +810,6 @@ class CondaMetadataTui(App[None]):
 
     def _selected_file_sha256(self) -> bytes | None:
         return self.query_one("#main-panel", MainPanel).selected_file_sha256()
-
-    def _file_path_at(self, index: int) -> str | None:
-        return self.query_one("#main-panel", MainPanel).file_path_at(index)
-
-    def _file_size_at(self, index: int) -> int | None:
-        return self.query_one("#main-panel", MainPanel).file_size_at(index)
-
-    def _file_sha256_at(self, index: int) -> bytes | None:
-        return self.query_one("#main-panel", MainPanel).file_sha256_at(index)
 
     def _open_matchspec_screen(
         self, initial_value: str, *, select_on_focus: bool = True
@@ -984,10 +951,6 @@ class CondaMetadataTui(App[None]):
             ],
         )
         return "\n".join([*navigation, "", *app])
-
-    @staticmethod
-    def _extract_rattler_build_version(rendered_recipe_text: str) -> str | None:
-        return VersionDataLoader.extract_rattler_build_version(rendered_recipe_text)
 
     async def _get_record_for_version_entry(
         self, package_name: str, entry: VersionEntry
@@ -2737,33 +2700,6 @@ class CondaMetadataTui(App[None]):
     def action_open_external_url(self, url: str) -> None:
         webbrowser.open(url)
 
-    def action_select_metadata_tab(self, tab: str) -> None:
-        if self._mode != "versions":
-            return
-        if tab not in METADATA_TABS:
-            return
-        self._set_active_main_section(0)
-        self._set_main_metadata_tab(cast(MetadataTab, tab))
-        self._focus_main_panel()
-
-    def action_select_dependency_tab(self, tab: str) -> None:
-        if self._mode != "versions":
-            return
-        if tab not in DEPENDENCY_TABS:
-            return
-        self._set_active_main_section(1)
-        self._set_main_dependency_tab(cast(DependencyTab, tab))
-        self._focus_main_panel()
-
-    def action_select_file_tab(self, tab: str) -> None:
-        if self._mode != "versions":
-            return
-        if tab not in FILE_TABS:
-            return
-        self._set_active_main_section(2)
-        self._set_main_file_tab(cast(FileTab, tab))
-        self._focus_main_panel()
-
     def action_tab_key(self) -> None:
         if self._compare_screen_open and isinstance(self.screen, CompareScreen):
             compare_screen = cast(CompareScreen, self.screen)
@@ -2825,16 +2761,10 @@ class CondaMetadataTui(App[None]):
                 f"who-needs: key w reached the app {self._whoneeds_key_context()}"
             )
 
+        # Tab and Shift+Tab never arrive here: the priority bindings on the app
+        # (and on the compare screen) consume them before ``on_key`` runs.
         if self._compare_screen_open and isinstance(self.screen, CompareScreen):
             compare_screen = cast(CompareScreen, self.screen)
-            if event.key == "tab":
-                compare_screen.action_next_section()
-                event.stop()
-                return
-            if event.key in {"shift+tab", "backtab"}:
-                compare_screen.action_previous_section()
-                event.stop()
-                return
             if event.key == "enter":
                 if compare_screen.file_section_is_active():
                     self._request_file_action_for_selected_compare_file()
@@ -2912,37 +2842,6 @@ class CondaMetadataTui(App[None]):
         if (
             self._mode == "versions"
             and self._main_panel_shows_version_details()
-            and self._main_panel_is_focused()
-            and event.key == "tab"
-        ):
-            self._cycle_active_main_section(1)
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and self._main_panel_shows_version_details()
-            and self._main_panel_is_focused()
-            and event.key in {"shift+tab", "backtab"}
-        ):
-            self._cycle_active_main_section(-1)
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and (
-                not self._main_panel_shows_version_details()
-                or not self._main_panel_is_focused()
-            )
-            and event.key in {"tab", "shift+tab", "backtab"}
-        ):
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and self._main_panel_shows_version_details()
             and event.character in {"1", "2", "3"}
         ):
             self._set_active_main_section(int(event.character) - 1)
@@ -2956,61 +2855,6 @@ class CondaMetadataTui(App[None]):
             return
 
         if event.character == "1" and self._mode in {"packages", "versions"}:
-            self._focus_main_panel()
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and event.character == "["
-            and self._selected_pane == "main"
-            and self.query_one("#main-panel", MainPanel).dependency_section_is_active()
-        ):
-            self._cycle_main_dependency_tab(-1)
-            self._focus_main_panel()
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and event.character == "["
-            and self._selected_pane == "main"
-            and self.query_one("#main-panel", MainPanel).file_section_is_active()
-        ):
-            self._cycle_main_file_tab(-1)
-            self._focus_main_panel()
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and event.character == "]"
-            and self._selected_pane == "main"
-            and self.query_one("#main-panel", MainPanel).dependency_section_is_active()
-        ):
-            self._cycle_main_dependency_tab(1)
-            self._focus_main_panel()
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and event.character == "]"
-            and self._selected_pane == "main"
-            and self.query_one("#main-panel", MainPanel).file_section_is_active()
-        ):
-            self._cycle_main_file_tab(1)
-            self._focus_main_panel()
-            event.stop()
-            return
-
-        if (
-            self._mode == "versions"
-            and event.character in {"[", "]"}
-            and self._selected_pane == "main"
-            and self.query_one("#main-panel", MainPanel).metadata_section_is_active()
-        ):
-            self._cycle_main_metadata_tab(-1 if event.character == "[" else 1)
             self._focus_main_panel()
             event.stop()
             return

--- a/pixi_browse/tui/widgets.py
+++ b/pixi_browse/tui/widgets.py
@@ -1008,34 +1008,6 @@ class MainPanel(Vertical):
             "#version-details-view", VersionDetailsView
         ).selected_file_sha256()
 
-    def file_path_at(self, index: int) -> str | None:
-        return self.query_one("#version-details-view", VersionDetailsView).file_path_at(
-            index
-        )
-
-    def file_size_at(self, index: int) -> int | None:
-        return self.query_one("#version-details-view", VersionDetailsView).file_size_at(
-            index
-        )
-
-    def file_sha256_at(self, index: int) -> bytes | None:
-        return self.query_one(
-            "#version-details-view", VersionDetailsView
-        ).file_sha256_at(index)
-
-    def set_metadata_tab(self, tab: MetadataTab) -> None:
-        self.query_one("#version-details-view", VersionDetailsView).set_metadata_tab(
-            tab
-        )
-
-    def set_dependency_tab(self, tab: DependencyTab) -> None:
-        self.query_one("#version-details-view", VersionDetailsView).set_dependency_tab(
-            tab
-        )
-
-    def set_file_tab(self, tab: FileTab) -> None:
-        self.query_one("#version-details-view", VersionDetailsView).set_file_tab(tab)
-
     def cycle_active_section(self, direction: int) -> None:
         self.query_one(
             "#version-details-view", VersionDetailsView
@@ -1102,20 +1074,12 @@ class MainPanel(Vertical):
         page_height = self.current_page_step()
         character = event.character
 
+        # Tab and Shift+Tab never arrive here: the app's priority bindings cycle
+        # the sections before the focused widget sees the key. The section
+        # shortcuts 1/2/3 bubble up to the app, which handles them for the
+        # focused and the unfocused panel alike.
         if self._showing_version_details():
             dependency_section_is_active = self.dependency_section_is_active()
-            if event.key == "tab":
-                self.cycle_active_section(1)
-                event.stop()
-                return
-            if event.key in {"shift+tab", "backtab"}:
-                self.cycle_active_section(-1)
-                event.stop()
-                return
-            if character in {"1", "2", "3"}:
-                self.set_active_section(int(character) - 1)
-                event.stop()
-                return
             if character == "[" and self.metadata_section_is_active():
                 self.cycle_metadata_tab(-1)
                 event.stop()
@@ -1473,10 +1437,6 @@ class CompareDetailsView(Vertical):
         )
 
     @staticmethod
-    def _row_style(row: CompareRow) -> tuple[str, str]:
-        return compare_row_styles(row)
-
-    @staticmethod
     def _file_row_style(row: CompareFileRow) -> str:
         if not row.comparison_known:
             return "#7a5c00"
@@ -1653,14 +1613,7 @@ class CompareDetailsView(Vertical):
         page_height = self.active_page_step()
         character = event.character
 
-        if event.key == "tab":
-            self.cycle_active_section(1)
-            event.stop()
-            return
-        if event.key in {"shift+tab", "backtab"}:
-            self.cycle_active_section(-1)
-            event.stop()
-            return
+        # Tab and Shift+Tab are handled by the compare screen's priority bindings.
         if character in {"1", "2", "3"}:
             self.set_active_section(int(character) - 1)
             event.stop()
@@ -1896,9 +1849,6 @@ class CompareScreen(Screen[None]):
         )
         self.query_one("#compare-details-view", CompareDetailsView).focus()
 
-    async def action_dismiss(self, result: None = None) -> None:
-        self.dismiss(result)
-
 
 class SidebarPanel(Vertical):
     def on_click(self, event: Click) -> None:
@@ -2051,11 +2001,6 @@ class ChannelScreen(ModalScreen[list[str] | None]):
     def __init__(self, channel_names: Sequence[str]) -> None:
         super().__init__()
         self._channel_names = list(channel_names)
-
-    @property
-    def channel_names(self) -> list[str]:
-        """The selection as currently edited."""
-        return list(self._channel_names)
 
     def compose(self) -> ComposeResult:
         with Vertical(id="channel-dialog"):
@@ -2270,9 +2215,6 @@ class MatchSpecScreen(ModalScreen[MatchSpec | Empty | None]):
 
         self.dismiss(result)
 
-    async def action_dismiss(self, result: MatchSpec | Empty | None = None) -> None:
-        self.dismiss(result)
-
 
 class WhoNeedsScreen(ModalScreen[PackageName | Empty | None]):
     DEFAULT_CSS = """
@@ -2381,9 +2323,6 @@ class WhoNeedsScreen(ModalScreen[PackageName | Empty | None]):
 
         self.dismiss(result)
 
-    async def action_dismiss(self, result: PackageName | Empty | None = None) -> None:
-        self.dismiss(result)
-
 
 class WhoNeedsConfirmScreen(ModalScreen[WhoNeedsConfirmChoice | None]):
     """Confirm a who-needs query for one concrete repodata entry.
@@ -2480,9 +2419,6 @@ class WhoNeedsConfirmScreen(ModalScreen[WhoNeedsConfirmChoice | None]):
     def _select_action(self, event: OptionList.OptionSelected) -> None:
         event.stop()
         self.dismiss(self.CHOICES[event.option_index][1])
-
-    async def action_dismiss(self, result: WhoNeedsConfirmChoice | None = None) -> None:
-        self.dismiss(result)
 
 
 class WhoNeedsLoadingScreen(ModalScreen[None]):
@@ -2654,9 +2590,6 @@ class FileActionScreen(ModalScreen[FileActionOption | None]):
         action = self._actions[event.option_index]
         self.dismiss(action)
 
-    async def action_dismiss(self, result: FileActionOption | None = None) -> None:
-        self.dismiss(result)
-
 
 class DownloadPathScreen(ModalScreen[str | None]):
     DEFAULT_CSS = """
@@ -2755,9 +2688,6 @@ class DownloadPathScreen(ModalScreen[str | None]):
             return
         self.dismiss(destination)
 
-    async def action_dismiss(self, result: str | None = None) -> None:
-        self.dismiss(result)
-
 
 class ScrollableModalScreen(ModalScreen[None]):
     """A modal whose body is a ``VerticalScroll`` driven by vim-style keys.
@@ -2809,10 +2739,6 @@ class ScrollableModalScreen(ModalScreen[None]):
 
     def action_scroll_end(self) -> None:
         self._scroll().scroll_end(animate=False)
-
-    async def action_dismiss(self, result: None = None) -> None:
-        del result
-        self.dismiss(None)
 
 
 class FilePreviewScreen(ScrollableModalScreen):
@@ -2982,6 +2908,3 @@ class HelpScreen(ModalScreen[None]):
         with Vertical(id="help-dialog"):
             yield Static(self._title_text(), id="help-title")
             yield Static(self._help_text, id="help-body")
-
-    async def action_dismiss(self, result: None = None) -> None:
-        self.dismiss(result)

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -1132,7 +1132,7 @@ package:
   name: demo
 """
 
-    assert CondaMetadataTui._extract_rattler_build_version(rendered_recipe) == "0.38.0"
+    assert VersionDataLoader.extract_rattler_build_version(rendered_recipe) == "0.38.0"
 
 
 def test_ensure_available_platforms_removes_unavailable_selected_platforms() -> None:


### PR DESCRIPTION
The source-only part of #100: removes code that cannot run or has no callers, without the new tests. The existing suite passes unchanged (266 tests, all snapshots identical).

## Removed

- **Tab/Shift+Tab handling** in the `on_key` handlers of the app, `MainPanel` and `CompareDetailsView`. The priority bindings on the app (`action_tab_key`/`action_backtab_key`) and on the compare screen consume those keys before any `on_key` runs.
- **`[`/`]` handling in the app's `on_key`** and the `_cycle_main_*_tab` wrappers. `MainPanel` handles the brackets whenever details are shown. The app copy only fired while the section placeholder was shown, and then silently flipped the tab of the *hidden* details view (verified on the old code: `k`, `l`, `]`, `h`, `j` opened the next artifact on the "Repodata patches" tab).
- **The `MainPanel` copy of the `1`/`2`/`3` section shortcuts.** The app already handles them for the focused and the unfocused panel alike after the key bubbles up.
- **`action_select_*_tab` on the app**, `_set_main_*_tab`, and the `MainPanel.set_*_tab` wrappers. Textual dispatches the `@click` actions of the tab labels to the `DetailSection` widget, which always defines those actions, so the app fallback is never reached.
- **Caller-less helpers:** the `_file_*_at` accessors on the app and `MainPanel`, `CompareDetailsView._row_style`, `ChannelScreen.channel_names`, and the app's `_extract_rattler_build_version` wrapper (the one test using it now calls the loader directly).
- **`action_dismiss` overrides on every screen**, which duplicated Textual's own `Screen.action_dismiss`.
- **The `clickable` parameter of `_metadata_rows_for_record`** and its four `_format_*` helpers. It was always called with the default; the clickable variants are produced by `format_version_details_metadata_lines`.
- **`Any`-typed fallbacks** in `format_byte_size`/`format_human_byte_size` (now `int | None` / `int`, sharing one `_scale_byte_size`) and the `isoformat` try/except in `format_record_value` (now an `isinstance(value, datetime)` check).

The `if __name__ == "__main__"` guard is marked `no cover` since it only runs as a subprocess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGAoHhHZpeUSDvwvC4iV2c

---
_Generated by [Claude Code](https://claude.ai/code/session_01NGAoHhHZpeUSDvwvC4iV2c)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved consistency and safety when displaying record metadata, URLs, provenance, dates, and file sizes.
  * Streamlined keyboard navigation across metadata, dependency, file, and comparison sections.
  * Standardized modal dismissal behavior through existing keyboard shortcuts.
* **Refactor**
  * Simplified internal navigation and rendering behavior without changing the primary browsing workflow.
* **Tests**
  * Updated version-related coverage to reflect the current data-loading flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->